### PR TITLE
Do not include the README in the documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ docs: ## Generate a documentation Docker container
 	docker run --rm \
 		-u $(shell id -u):$(shell id -g) \
 		-v $(shell pwd)/docs:/documents/kukur \
-		-v $(shell pwd)/README.asciidoc:/documents/README.asciidoc \
 		-v $(shell pwd)/docs/out:/documents/kukur/out \
 		asciidoctor/docker-asciidoctor \
 		asciidoctor -r asciidoctor-diagram --destination-dir kukur/out --out-file index.html kukur/kukur.asciidoc

--- a/docs/kukur.asciidoc
+++ b/docs/kukur.asciidoc
@@ -8,7 +8,29 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-include::../README.asciidoc[leveloffset=+1]
+== What is Kukur?
+
+Kukur makes time series data and metadata available to the https://arrow.apache.org/[Apache Arrow] ecosystem.
+
+[WARNING]
+====
+Kukur is under active development.
+Breaking changes to the interfaces are possible.
+
+Kukur uses semantic versioning.
+While `< 1.0.0`, changes to the minor version indicate breaking changes.
+====
+
+== Usage
+
+Kukur can be used as a Python library or as a standalone application that exposes an Arrow Flight interface.
+
+== Development
+
+Kukur is developed on GitHub.
+Visit https://github.com/timeseer-ai/kukur to learn more.
+
+Kukur is open source software, licensed under the Apache License, Version 2.0.
 
 == Sources
 


### PR DESCRIPTION
This allows the README to be converted to Markdown in order to publish
it on pypi.