### PR TITLE
Add PEP-561 type marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,7 @@ setuptools.setup(
           'toml',
       ],
     python_requires='>=3.6',
+    package_data = {
+        'kukur': ['py.typed'],
+    },
 )


### PR DESCRIPTION
Without this, the module is not picked up for type checking when used as
a dependency.