### PR TITLE
Publish Kukur releases to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
         run: make integration-test
 
       - name: Tag docker image
+        run: docker tag kukur:latest docker.timeseer.ai/kukur:${GITHUB_SHA}
+        if: github.ref == 'refs/heads/master'
+
+      - name: Tag latest docker image
         run: docker tag kukur:latest docker.timeseer.ai/kukur:latest
         if: github.ref == 'refs/heads/master'
 
@@ -46,6 +50,10 @@ jobs:
           login-server: docker.timeseer.ai
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+        if: github.ref == 'refs/heads/master'
+
+      - name: Push docker image
+        run: docker push docker.timeseer.ai/kukur:${GITHUB_SHA}
         if: github.ref == 'refs/heads/master'
 
       - name: Push docker image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     - v*
 
 jobs:
-  build:
+  pypi:
     name: Publish version to PyPI
     runs-on: ubuntu-latest
     steps:
@@ -18,7 +18,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Set env
+    - name: Set version in environment
       run: echo "KUKUR_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
     - name: Install pypa
@@ -36,3 +36,39 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_KUKUR_API_TOKEN }}
+
+  docker_hub:
+    name: Publish docker container for this version to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set version in environment
+      run: echo "KUKUR_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+    - name: Login to Timeseer docker registry
+      uses: azure/docker-login@v1
+      with:
+        login-server: docker.timeseer.ai
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Pull docker image
+      run: docker pull docker.timeseer.ai/kukur:${GITHUB_SHA}
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+    - name: Tag docker image
+      run: docker tag docker.timeseer.ai/kukur:${GITHUB_SHA} timeseer/kukur:${KUKUR_VERSION}
+
+    - name: Tag docker image as latest version
+      run: docker tag docker.timeseer.ai/kukur:${GITHUB_SHA} timeseer/kukur:latest
+
+    - name: Push docker image
+      run: docker push timeseer/kukur:${KUKUR_VERSION}
+
+    - name: Push latest docker image
+      run: docker push timeseer/kukur:${KUKUR_VERSION}


### PR DESCRIPTION
This changes the CI strategy to keep all master images. They will be cleaned up when older than 7 days.
