### PR TITLE
Do not fail on empty intervals

### DIFF
--- a/kukur/source/__init__.py
+++ b/kukur/source/__init__.py
@@ -134,12 +134,11 @@ class SourceWrapper:
         """Return the data for the given series in the given time frame, taking into account the request policy."""
         if start_date == end_date or selector.name is None:
             return pa.Table.from_pydict({"ts": [], "values": []})
-        return pa.concat_tables(
-            [
-                self.__source.data.get_data(selector, start, end)
-                for start, end in self.__to_intervals(start_date, end_date)
-            ]
-        )
+        tables = [
+            self.__source.data.get_data(selector, start, end)
+            for start, end in self.__to_intervals(start_date, end_date)
+        ]
+        return pa.concat_tables([table for table in tables if len(table) > 0])
 
     def __to_intervals(
         self, start_date: datetime, end_date: datetime

--- a/tests/source/test_source_wrapper.py
+++ b/tests/source/test_source_wrapper.py
@@ -1,11 +1,16 @@
 # SPDX-FileCopyrightText: 2021 Timeseer.AI
-#
 # SPDX-License-Identifier: Apache-2.0
+
 from datetime import datetime, timedelta
 
 import pyarrow as pa
 
 from kukur.source import Source, SourceWrapper, SeriesSelector, Metadata
+
+
+SELECTOR = SeriesSelector("fake", "test-tag-1")
+START_DATE = datetime.fromisoformat("2020-01-01T00:00:00+00:00")
+END_DATE = datetime.fromisoformat("2020-02-01T00:00:00+00:00")
 
 
 class FakeSource:
@@ -33,82 +38,85 @@ class EmptyOddHoursSource:
         return pa.Table.from_pydict({"ts": [], "value": []})
 
 
-class TestSourceWrapper:
+def test_split_none():
+    wrapper = SourceWrapper(_make_source(), [], {})
+    result = wrapper.get_data(SELECTOR, START_DATE, END_DATE)
+    assert len(result) == 2
+    data = result.to_pydict()
+    assert data["ts"][0] == START_DATE
+    assert data["value"][0] == 42
+    assert data["ts"][1] == END_DATE
+    assert data["value"][1] == 24
 
-    selector = SeriesSelector("fake", "test-tag-1")
-    start_date = datetime.fromisoformat("2020-01-01T00:00:00+00:00")
-    end_date = datetime.fromisoformat("2020-02-01T00:00:00+00:00")
 
-    def test_split_none(self):
-        wrapper = SourceWrapper(_make_source(), [], {})
-        result = wrapper.get_data(self.selector, self.start_date, self.end_date)
-        assert len(result) == 2
-        data = result.to_pydict()
-        assert data["ts"][0] == self.start_date
-        assert data["value"][0] == 42
-        assert data["ts"][1] == self.end_date
-        assert data["value"][1] == 24
+def test_split_equal_start_end():
+    wrapper = SourceWrapper(
+        _make_source(), [], {"data_query_interval_seconds": 24 * 60 * 60}
+    )
+    result = wrapper.get_data(SELECTOR, START_DATE, START_DATE)
+    assert len(result) == 0
 
-    def test_split_equal_start_end(self):
-        wrapper = SourceWrapper(
-            _make_source(), [], {"data_query_interval_seconds": 24 * 60 * 60}
-        )
-        result = wrapper.get_data(self.selector, self.start_date, self.start_date)
-        assert len(result) == 0
 
-    def test_split_one_day(self):
-        wrapper = SourceWrapper(
-            _make_source(), [], {"data_query_interval_seconds": 24 * 60 * 60}
-        )
-        result = wrapper.get_data(self.selector, self.start_date, self.end_date)
-        assert len(result) == 62
-        data = result.to_pydict()
-        assert data["ts"][0] == self.start_date
-        assert data["value"][0] == 42
-        assert data["ts"][1] == self.start_date + timedelta(seconds=24 * 60 * 60)
-        assert data["value"][1] == 24
-        assert data["ts"][61] == self.end_date
-        assert data["value"][61] == 24
+def test_split_one_day():
+    wrapper = SourceWrapper(
+        _make_source(), [], {"data_query_interval_seconds": 24 * 60 * 60}
+    )
+    result = wrapper.get_data(SELECTOR, START_DATE, END_DATE)
+    assert len(result) == 62
+    data = result.to_pydict()
+    assert data["ts"][0] == START_DATE
+    assert data["value"][0] == 42
+    assert data["ts"][1] == START_DATE + timedelta(seconds=24 * 60 * 60)
+    assert data["value"][1] == 24
+    assert data["ts"][61] == END_DATE
+    assert data["value"][61] == 24
 
-    def test_split_partial_end_interval(self):
-        end_date = datetime.fromisoformat("2020-01-31T12:00:00+00:00")
 
-        wrapper = SourceWrapper(
-            _make_source(), [], {"data_query_interval_seconds": 24 * 60 * 60}
-        )
-        result = wrapper.get_data(self.selector, self.start_date, end_date)
-        assert len(result) == 62
-        data = result.to_pydict()
-        assert data["ts"][0] == self.start_date
-        assert data["value"][0] == 42
-        assert data["ts"][1] == self.start_date + timedelta(seconds=24 * 60 * 60)
-        assert data["value"][1] == 24
-        assert data["ts"][61] == end_date
-        assert data["value"][61] == 24
+def test_split_partial_end_interval():
+    end_date = datetime.fromisoformat("2020-01-31T12:00:00+00:00")
 
-    def test_split_partial_interval(self):
-        end_date = self.start_date + timedelta(seconds=60)
+    wrapper = SourceWrapper(
+        _make_source(), [], {"data_query_interval_seconds": 24 * 60 * 60}
+    )
+    result = wrapper.get_data(SELECTOR, START_DATE, end_date)
+    assert len(result) == 62
+    data = result.to_pydict()
+    assert data["ts"][0] == START_DATE
+    assert data["value"][0] == 42
+    assert data["ts"][1] == START_DATE + timedelta(seconds=24 * 60 * 60)
+    assert data["value"][1] == 24
+    assert data["ts"][61] == end_date
+    assert data["value"][61] == 24
 
-        wrapper = SourceWrapper(
-            _make_source(), [], {"data_query_interval_seconds": 24 * 60 * 60}
-        )
-        result = wrapper.get_data(self.selector, self.start_date, end_date)
-        assert len(result) == 2
-        data = result.to_pydict()
-        assert data["ts"][0] == self.start_date
-        assert data["value"][0] == 42
-        assert data["ts"][1] == end_date
-        assert data["value"][1] == 24
 
-    def test_empty_interval(self):
-        source = EmptyOddHoursSource()
-        wrapper = SourceWrapper(
-            Source(source, source), [], {"data_query_interval_seconds": 60 * 60}
-        )
+def test_split_partial_interval():
+    end_date = START_DATE + timedelta(seconds=60)
 
-        end_date = datetime.fromisoformat("2020-01-02T00:00:00+00:00")
-        result = wrapper.get_data(self.selector, self.start_date, end_date)
-        assert len(result) == 24
+    wrapper = SourceWrapper(
+        _make_source(), [], {"data_query_interval_seconds": 24 * 60 * 60}
+    )
+    result = wrapper.get_data(SELECTOR, START_DATE, end_date)
+    assert len(result) == 2
+    data = result.to_pydict()
+    assert data["ts"][0] == START_DATE
+    assert data["value"][0] == 42
+    assert data["ts"][1] == end_date
+    assert data["value"][1] == 24
+
+
+def test_empty_interval():
+    source = EmptyOddHoursSource()
+    wrapper = SourceWrapper(
+        Source(source, source), [], {"data_query_interval_seconds": 60 * 60}
+    )
+
+    end_date = datetime.fromisoformat("2020-01-02T00:00:00+00:00")
+    result = wrapper.get_data(SELECTOR, START_DATE, end_date)
+    assert len(result) == 24
+    data = result.to_pydict()
+    assert data["ts"][0] == START_DATE
+    assert data["ts"][1] == START_DATE + timedelta(hours=1)
+    assert data["ts"][2] == START_DATE + timedelta(hours=2)
 
 
 def _make_source():


### PR DESCRIPTION
This avoids:

```
E   pyarrow.lib.ArrowInvalid: Schema at index 1 was different: 
E   ts: timestamp[us, tz=UTC]
E   value: int64
E   vs
E   ts: null
E   value: null
```