### PR TITLE
PI driver had issue with a datetime that contains timezone informatio…

### DIFF
--- a/docs/source/adodb.asciidoc
+++ b/docs/source/adodb.asciidoc
@@ -32,6 +32,7 @@ metadata_value_mapping = "<metadata_value_mapping name>"
 data_query = "<query for data of one series in time range>"
 data_query_path = "<path to data query>"
 data_query_datetime_format = "<strftime format>"
+data_query_timezone = "<override or specify time zone of timestamps to send a naive timestamp to the adodb driver>"
 data_timezone = "<override or specify time zone of timestamps returned by the adodb driver>"
 ```
 
@@ -206,6 +207,15 @@ data_query_datetime_format = "%Y-%m-%dT%H:%M:%S%z"
 ```
 
 This converts timestamps to the ISO8601 format.
+
+If the driver doesn't accept timezoned timestamps you can specify the prefered timestamp for the input to convert the timestamp with the `data_query_timezone` option.
+The request will use the converted timestamps as naive timestamps for the queries to the driver.
+
+Example:
+
+```toml
+data_query_timezone = "UTC"
+```
 
 If the query or driver returns dates without a time zone,
 the time zone can be specified by the `data_timezone` option.

--- a/docs/source/odbc.asciidoc
+++ b/docs/source/odbc.asciidoc
@@ -26,6 +26,7 @@ dictionary_query_path = "<path to a dictionary query>"
 metadata_value_mapping = "<metadata_value_mapping name>"
 data_query = "<query for data of one series in time range>"
 data_query_path = "<path to data query>"
+data_query_timezone = "<override or specify time zone of timestamps to send a naive timestamp to the odbc driver>"
 data_timezone = "<override or specify time zone of timestamps returned by the odbc driver>"
 ```
 
@@ -220,6 +221,15 @@ data_query_datetime_format = "%Y-%m-%dT%H:%M:%S%z"
 This converts timestamps to the ISO8601 format.
 
 The data query can be read from a file by using `data_query_path` instead of `data_query`.
+
+If the driver doesn't accept timezoned timestamps you can specify the prefered timestamp for the input to convert the timestamp with the `data_query_timezone` option.
+The request will use the converted timestamps as naive timestamps for the queries to the driver.
+
+Example:
+
+```toml
+data_query_timezone = "UTC"
+```
 
 If the query or driver returns dates without a time zone,
 the time zone can be specified by the `data_timezone` option.

--- a/kukur/source/sql.py
+++ b/kukur/source/sql.py
@@ -36,6 +36,7 @@ class SQLConfig:  # pylint: disable=too-many-instance-attributes
     data_query: Optional[str] = None
     data_query_datetime_format: Optional[str] = None
     data_timezone: Optional[tzinfo] = None
+    data_query_timezone: Optional[tzinfo] = None
 
     @classmethod
     def from_dict(cls, data):
@@ -71,6 +72,10 @@ class SQLConfig:  # pylint: disable=too-many-instance-attributes
         config.query_string_parameters = data.get("query_string_parameters", False)
         if "data_timezone" in data:
             config.data_timezone = dateutil.tz.gettz(data.get("data_timezone"))
+        if "data_query_timezone" in data:
+            config.data_query_timezone = dateutil.tz.gettz(
+                data.get("data_query_timezone")
+            )
 
         return config
 
@@ -226,6 +231,9 @@ class BaseSQLSource(ABC):
     def __format_date(self, date):
         if self._config.data_query_datetime_format is not None:
             return date.strftime(self._config.data_query_datetime_format)
+        if self._config.data_query_timezone:
+            date = date.replace(tzinfo=self._config.data_timezone)
+            return date.replace(tzinfo=None)
         return date
 
     @abstractmethod


### PR DESCRIPTION
…n when fetching data.

For the get_data sql query we remove the timezone from the datetime type so that normal evaluation can be resumed.

This closes #350