### PR TITLE
pa.concat_tables expects at least one non-empty table

### DIFF
--- a/kukur/source/__init__.py
+++ b/kukur/source/__init__.py
@@ -138,7 +138,10 @@ class SourceWrapper:
             self.__source.data.get_data(selector, start, end)
             for start, end in self.__to_intervals(start_date, end_date)
         ]
-        return pa.concat_tables([table for table in tables if len(table) > 0])
+        tables = [table for table in tables if len(table) > 0]
+        if len(tables) == 0:
+            return pa.Table.from_pydict({"ts": [], "values": []})
+        return pa.concat_tables(tables)
 
     def __to_intervals(
         self, start_date: datetime, end_date: datetime

--- a/tests/source/test_source_wrapper.py
+++ b/tests/source/test_source_wrapper.py
@@ -38,6 +38,25 @@ class EmptyOddHoursSource:
         return pa.Table.from_pydict({"ts": [], "value": []})
 
 
+class EmptySource:
+    def get_metadata(self, selector: SeriesSelector) -> Metadata:
+        return Metadata(selector)
+
+    def get_data(
+        self, _: SeriesSelector, start_date: datetime, end_date: datetime
+    ) -> pa.Table:
+        return pa.Table.from_pydict({"ts": [], "value": []})
+
+
+def test_split_empty():
+    source = EmptySource()
+    wrapper = SourceWrapper(
+        Source(source, source), [], {"data_query_interval_seconds": 60 * 60}
+    )
+    result = wrapper.get_data(SELECTOR, START_DATE, END_DATE)
+    assert len(result) == 0
+
+
 def test_split_none():
     wrapper = SourceWrapper(_make_source(), [], {})
     result = wrapper.get_data(SELECTOR, START_DATE, END_DATE)


### PR DESCRIPTION
This closes timeseer-ai/timeseer#367.