### PR TITLE
Take query time zone into account during string formatting

### DIFF
--- a/kukur/source/sql.py
+++ b/kukur/source/sql.py
@@ -243,11 +243,12 @@ class BaseSQLSource(ABC):
         return Dictionary(mapping)
 
     def __format_date(self, date):
+        if self._config.data_query_timezone:
+            date = date.astimezone(self._config.data_query_timezone).replace(
+                tzinfo=None
+            )
         if self._config.data_query_datetime_format is not None:
             return date.strftime(self._config.data_query_datetime_format)
-        if self._config.data_query_timezone:
-            date = date.replace(tzinfo=self._config.data_timezone)
-            return date.replace(tzinfo=None)
         return date
 
     @abstractmethod


### PR DESCRIPTION
String formatting happened before time zone conversion.

Also, the time zone conversion was not working. `replace` does not change
the timestamp, only changes the time zone information associated with
it, while converting requires the actual timestamp to change.

This fixes #64.