### PR TITLE
Make Kukur compatible with Python 3.8 again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: '3.8'
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.8'
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/kukur/app.py
+++ b/kukur/app.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
-from typing import Any, Generator, Optional, Union
+from typing import Any, Dict, Generator, List, Optional, Union
 from pathlib import Path
 
 import json
@@ -24,7 +24,7 @@ class Kukur:
 
     __repository: RepositoryRegistry
 
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, config: Dict[str, Any]):
         self.__source_factory = SourceFactory(config)
         self.__repository = RepositoryRegistry(
             data_dir=Path(config.get("data_dir", "."))
@@ -61,7 +61,7 @@ class Kukur:
         """Return the api keys."""
         return ApiKeys(self.__repository)
 
-    def list_sources(self, *_) -> list[bytes]:
+    def list_sources(self, *_) -> List[bytes]:
         """Return all the configured sources."""
         sources = self.__source_factory.get_source_names()
         return [json.dumps(sources).encode()]

--- a/kukur/base.py
+++ b/kukur/base.py
@@ -5,7 +5,7 @@
 
 from dataclasses import dataclass, field as data_field
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 
 @dataclass
@@ -20,7 +20,7 @@ class Dictionary:
 
     In Python 3.8+, iteration over a dict keeps the insert ordering."""
 
-    mapping: dict[int, str]
+    mapping: Dict[int, str]
 
 
 @dataclass
@@ -31,13 +31,13 @@ class SeriesSearch:
     """
 
     source: str
-    tags: dict[str, str] = data_field(default_factory=dict)
+    tags: Dict[str, str] = data_field(default_factory=dict)
     field: Optional[str] = None
 
     def __init__(
         self,
         source: str,
-        tags: Union[str, dict[str, str]] = None,
+        tags: Union[str, Dict[str, str]] = None,
         field: Optional[str] = None,
     ):
         tags_dict = {}
@@ -54,7 +54,7 @@ class SeriesSearch:
         """Get the series name with tags and fields included.
 
         For sources that cannot handle tags and fields yet."""
-        series_tags: list[str] = []
+        series_tags: List[str] = []
         for tag_key, tag_value in self.tags.items():
             if tag_key == "series name":
                 series_tags.insert(0, tag_value)
@@ -65,7 +65,7 @@ class SeriesSearch:
             return f"{series_string}"
         return f"{series_string}::{self.field}"
 
-    def to_data(self) -> dict[str, Any]:
+    def to_data(self) -> Dict[str, Any]:
         """Convert to JSON object."""
         return dict(source=self.source, tags=self.tags, field=self.field)
 
@@ -79,28 +79,28 @@ class SeriesSelector(SeriesSearch):
     def __init__(
         self,
         source: str,
-        tags: Union[str, dict[str, str]] = None,
+        tags: Union[str, Dict[str, str]] = None,
         field: str = "value",
     ):
         super().__init__(source, tags)
         self.field = field
 
     @classmethod
-    def from_tags(cls, source: str, tags: dict[str, str], field: Optional[str] = None):
+    def from_tags(cls, source: str, tags: Dict[str, str], field: Optional[str] = None):
         """Create the SeriesSelector from tags."""
         if field is None:
             field = "value"
         return cls(source, tags, field)
 
     @classmethod
-    def from_data(cls, data: dict[str, Any]):
+    def from_data(cls, data: Dict[str, Any]):
         """Create a Series from a dictionary."""
         tags = data.get("tags", {})
         if "name" in data and "tags" not in data:
             tags["series name"] = data["name"]
         return cls(data["source"], tags, data.get("field", "value"))
 
-    def to_data(self) -> dict[str, Any]:
+    def to_data(self) -> Dict[str, Any]:
         """Convert to JSON object."""
         return dict(source=self.source, tags=self.tags, field=self.field)
 
@@ -109,7 +109,7 @@ class SeriesSelector(SeriesSearch):
         """Get the series name with tags and fields included.
 
         For sources that cannot handle tags and fields yet."""
-        series_tags: list[str] = []
+        series_tags: List[str] = []
         for tag_key, tag_value in self.tags.items():
             if tag_key == "series name":
                 series_tags.insert(0, tag_value)
@@ -149,12 +149,12 @@ class DataType(Enum):
 class SourceStructure:
     """The SourceStructure defines the fields and tags that are present in the source."""
 
-    fields: list[str]
-    tag_keys: list[str]
-    tag_values: list[dict]
+    fields: List[str]
+    tag_keys: List[str]
+    tag_values: List[dict]
 
     @classmethod
-    def from_data(cls, data: dict[str, Any]) -> "SourceStructure":
+    def from_data(cls, data: Dict[str, Any]) -> "SourceStructure":
         """Create a SourceStructure from a dictionary."""
         return cls(data["fields"], data["tagKeys"], data["tagValues"])
 

--- a/kukur/client.py
+++ b/kukur/client.py
@@ -5,7 +5,7 @@
 import json
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, Generator, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 import pyarrow as pa
 import pyarrow.flight as fl
@@ -108,7 +108,7 @@ class Client:
         ticket = fl.Ticket(json.dumps(query))
         return self._get_client().do_get(ticket).read_all()
 
-    def list_sources(self) -> list[str]:
+    def list_sources(self) -> List[str]:
         """List all configured sources.
 
         Returns:
@@ -145,7 +145,7 @@ class Client:
         return self._client
 
 
-def _read_metadata(data: dict[str, Any]) -> Metadata:
+def _read_metadata(data: Dict[str, Any]) -> Metadata:
     return Metadata.from_data(data)
 
 

--- a/kukur/flight.py
+++ b/kukur/flight.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
 
-from typing import Any, Callable, Generator
+from typing import Any, Callable, Dict, Generator, List
 
 import pyarrow.flight as fl
 
@@ -24,10 +24,10 @@ class JSONFlightServer(fl.FlightServerBase):
     It supports registering custom actions and request handlers. Register a GET
     handler to return Arrow data. To return JSON, register an action handler."""
 
-    __get_handlers: dict[str, Callable]
-    __action_handlers: dict[str, Callable]
+    __get_handlers: Dict[str, Callable]
+    __action_handlers: Dict[str, Callable]
 
-    def __init__(self, config: dict[str, Any], **kwargs):
+    def __init__(self, config: Dict[str, Any], **kwargs):
         host = "0.0.0.0"
         port = 8081
         if "flight" in config:
@@ -92,7 +92,7 @@ class KukurFlightServer:
                 }
                 yield json.dumps(series).encode()
 
-    def get_metadata(self, _, action: fl.Action) -> list[bytes]:
+    def get_metadata(self, _, action: fl.Action) -> List[bytes]:
         """Return metadata for the given time series as JSON."""
         request = json.loads(action.body.to_pybytes())
         selector = SeriesSelector.from_data(request)
@@ -107,7 +107,7 @@ class KukurFlightServer:
         data = self.__source.get_data(selector, start_date, end_date)
         return fl.RecordBatchStream(data)
 
-    def get_source_structure(self, _, action: fl.Action) -> list[bytes]:
+    def get_source_structure(self, _, action: fl.Action) -> List[bytes]:
         """Return the structure of a source for the given time series as JSON."""
         request = json.loads(action.body.to_pybytes())
         selector = SeriesSelector.from_data(request)

--- a/kukur/metadata/__init__.py
+++ b/kukur/metadata/__init__.py
@@ -7,7 +7,7 @@ They have been defined here. Users of Kukur can define their own metadata fields
 # SPDX-FileCopyrightText: 2021 Timeseer.AI
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Generator, Optional, TypeVar, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, TypeVar, Union
 
 from kukur.base import SeriesSelector
 
@@ -23,13 +23,13 @@ class MetadataFields:
     Alternatively, untyped methods that accept fields by name are also available.
     """
 
-    _fields: list[MetadataField] = []
-    __values: dict[Union[str, MetadataField], Any]
+    _fields: List[MetadataField] = []
+    __values: Dict[Union[str, MetadataField], Any]
 
     def __init__(
         self,
-        fields: list[MetadataField],
-        values: Optional[dict[MetadataField, Any]] = None,
+        fields: List[MetadataField],
+        values: Optional[Dict[MetadataField, Any]] = None,
     ):
         self._fields = fields
         self.__values = {k: k.default() for k in self._fields}
@@ -37,12 +37,12 @@ class MetadataFields:
             for field, value in values.items():
                 self.__values[field] = value
 
-    def iter_fields(self) -> Generator[tuple[MetadataField, Any], None, None]:
+    def iter_fields(self) -> Generator[Tuple[MetadataField, Any], None, None]:
         """Iterate over all typed metadata fields and their values."""
         for field in self._fields:
             yield (field, field.calculated_value(self, self.__values.get(field)))
 
-    def iter_names(self) -> Generator[tuple[str, Any], None, None]:
+    def iter_names(self) -> Generator[Tuple[str, Any], None, None]:
         """Iterate over all metadata fields (typed and untyped) and return their names and values."""
         for field, value in self.__values.items():
             if isinstance(field, MetadataField):
@@ -50,7 +50,7 @@ class MetadataFields:
             else:
                 yield (field, value)
 
-    def iter_serialized(self) -> Generator[tuple[str, Any], None, None]:
+    def iter_serialized(self) -> Generator[Tuple[str, Any], None, None]:
         """Iterate over all metadata fields, but use the human readable names and serialized values."""
         for field, value in self.__values.items():
             if isinstance(field, MetadataField):
@@ -111,7 +111,7 @@ class MetadataFields:
             return self.__values[field_name]
         return self.get_field(field)
 
-    def to_data(self) -> dict[str, Any]:
+    def to_data(self) -> Dict[str, Any]:
         """Convert the metadata to a Dictionary with camelcase keys as expected in JSON."""
         data = {}
         for field, value in self.__values.items():
@@ -131,7 +131,7 @@ class MetadataFields:
 class Metadata(MetadataFields):
     """Metadata fields for one time series."""
 
-    _fields: list[MetadataField] = []
+    _fields: List[MetadataField] = []
     series: SeriesSelector
 
     @classmethod
@@ -148,7 +148,7 @@ class Metadata(MetadataFields):
 
     @classmethod
     def from_data(
-        cls, data: dict[str, Any], series: Optional[SeriesSelector] = None
+        cls, data: Dict[str, Any], series: Optional[SeriesSelector] = None
     ) -> "Metadata":
         """Create a new Metadata object from a dictionary produced by to_data().
 
@@ -167,7 +167,7 @@ class Metadata(MetadataFields):
     def __init__(
         self,
         series: SeriesSelector,
-        values: Optional[dict[MetadataField, Any]] = None,
+        values: Optional[Dict[MetadataField, Any]] = None,
     ):
         super().__init__(self._fields, values)
         self.series = series
@@ -176,7 +176,7 @@ class Metadata(MetadataFields):
         data = dict(self.iter_names())
         return f"Metadata({self.series}, {data})"
 
-    def to_data(self) -> dict[str, Any]:
+    def to_data(self) -> Dict[str, Any]:
         """Convert the metadata to a Dictionary with camelcase keys as expected in JSON."""
         data = super().to_data()
         data["series"] = self.series.to_data()

--- a/kukur/metadata/fields.py
+++ b/kukur/metadata/fields.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2021 Timeseer.AI
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any, Callable, Generic, Optional, TypeVar
+from typing import Any, Callable, Generic, List, Optional, Tuple, TypeVar
 
 from kukur.base import (
     DataType as KukurDataType,
@@ -220,14 +220,14 @@ DictionaryName = MetadataField[Optional[str]](
 
 def _dictionary_to_json(
     dictionary: Optional[KukurDictionary],
-) -> Optional[list[tuple[int, str]]]:
+) -> Optional[List[Tuple[int, str]]]:
     if dictionary is None:
         return None
     return list(dictionary.mapping.items())
 
 
 def _dictionary_from_json(
-    dictionary: Optional[list[tuple[int, str]]]
+    dictionary: Optional[List[Tuple[int, str]]]
 ) -> Optional[KukurDictionary]:
     if dictionary is None:
         return None

--- a/kukur/source/csv/csv.py
+++ b/kukur/source/csv/csv.py
@@ -14,7 +14,7 @@ import csv
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Generator, Optional
+from typing import Any, Dict, Generator, List, Optional
 
 import pyarrow as pa
 import pyarrow.csv
@@ -37,7 +37,7 @@ class InvalidMetadataError(KukurException):
 
 
 def from_config(
-    config: dict[str, Any],
+    config: Dict[str, Any],
     metadata_mapper: MetadataMapper,
     metadata_value_mapper: MetadataValueMapper,
     quality_mapper: QualityMapper,
@@ -51,7 +51,7 @@ def from_config(
     if "dictionary_dir" in config:
         loaders.dictionary = loader_from_config(config, "dictionary_dir", "r")
     data_format = config.get("format", "row")
-    metadata_fields: list[str] = config.get("metadata_fields", [])
+    metadata_fields: List[str] = config.get("metadata_fields", [])
     if len(metadata_fields) == 0:
         metadata_fields = config.get("fields", [])
     mappers = CSVMappers(metadata_mapper, metadata_value_mapper, quality_mapper)
@@ -81,13 +81,13 @@ class CSVSource:
 
     __loaders: CSVLoaders
     __data_format: str
-    __metadata_fields: list[str]
+    __metadata_fields: List[str]
     __mappers: CSVMappers
 
     def __init__(
         self,
         data_format: str,
-        metadata_fields: list[str],
+        metadata_fields: List[str],
         loaders: CSVLoaders,
         mappers: CSVMappers,
     ):

--- a/kukur/source/influxdb/influxdb.py
+++ b/kukur/source/influxdb/influxdb.py
@@ -6,7 +6,7 @@
 import json
 
 from datetime import datetime
-from typing import Any, Generator, Optional, Tuple
+from typing import Any, Dict, Generator, Optional, Tuple
 
 import dateutil.parser
 import pyarrow as pa
@@ -30,7 +30,7 @@ class InvalidClientConnection(KukurException):
         KukurException.__init__(self, f"Connection error: {message}")
 
 
-def from_config(config: dict[str, Any]):
+def from_config(config: Dict[str, Any]):
     """Create a new Influx data source"""
     if not HAS_INFLUX:
         raise MissingModuleException("influxdb", "influxdb")
@@ -156,7 +156,7 @@ class InfluxSource:
         return SourceStructure(fields, tag_keys, tag_values)
 
 
-def _parse_influx_series(series: str) -> Tuple[str, dict[str, str]]:
+def _parse_influx_series(series: str) -> Tuple[str, Dict[str, str]]:
     series_name = series.replace("\\", "")
     measurement = series_name.split(",")[0]
     tags = {}

--- a/kukur/source/kukur/kukur.py
+++ b/kukur/source/kukur/kukur.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
-from typing import Any, Generator, Optional, Tuple, Union
+from typing import Any, Dict, Generator, Optional, Tuple, Union
 
 import pyarrow as pa
 
@@ -12,7 +12,7 @@ from kukur.client import Client
 from kukur.exceptions import InvalidDataError
 
 
-def from_config(config: dict[str, Any]):
+def from_config(config: Dict[str, Any]):
     """Create a new Kukur source"""
     source_name = config["source"]
     host = config.get("host", "localhost")

--- a/kukur/source/piwebapi_da/piwebapi_da.py
+++ b/kukur/source/piwebapi_da/piwebapi_da.py
@@ -5,7 +5,7 @@
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Generator, Optional
+from typing import Dict, Generator, Optional
 
 import pyarrow as pa
 
@@ -59,8 +59,8 @@ class _DictionaryLookup:  # pylint: disable=too-few-public-methods
         self.__session = session
         self.__request_properties = request_properties
         self.__data_archive = data_archive
-        self.__digital_set_links: Optional[dict[str, str]] = None
-        self.__dictionaries: dict[str, Dictionary] = {}
+        self.__digital_set_links: Optional[Dict[str, str]] = None
+        self.__dictionaries: Dict[str, Dictionary] = {}
 
     def get(self, name: str) -> Dictionary:
         """Return a dictionary with the given name.
@@ -86,7 +86,7 @@ class _DictionaryLookup:  # pylint: disable=too-few-public-methods
             }
         )
 
-    def _get_digital_set_links(self) -> dict[str, str]:
+    def _get_digital_set_links(self) -> Dict[str, str]:
         response = self.__session.get(
             self.__data_archive["Links"]["EnumerationSets"],
             verify=self.__request_properties.verify_ssl,

--- a/kukur/source/sql.py
+++ b/kukur/source/sql.py
@@ -8,7 +8,7 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone, tzinfo
-from typing import Generator, Optional, Union
+from typing import Dict, Generator, List, Optional, Union
 
 import dateutil.parser
 import pyarrow as pa
@@ -36,9 +36,9 @@ class SQLConfig:  # pylint: disable=too-many-instance-attributes
     connection_string: str
     query_string_parameters: bool = False
     list_query: Optional[str] = None
-    list_columns: list[str] = field(default_factory=list)
+    list_columns: List[str] = field(default_factory=list)
     metadata_query: Optional[str] = None
-    metadata_columns: list[str] = field(default_factory=list)
+    metadata_columns: List[str] = field(default_factory=list)
     dictionary_query: Optional[str] = None
     data_query: Optional[str] = None
     data_query_datetime_format: Optional[str] = None
@@ -274,7 +274,7 @@ class BaseSQLSource(ABC):
     def __query_dictionary(self, cursor, dictionary_name: str) -> Optional[Dictionary]:
         if self._config.dictionary_query is None:
             return None
-        mapping: dict[int, str] = {}
+        mapping: Dict[int, str] = {}
 
         query = self._config.dictionary_query
         params = [dictionary_name]

--- a/kukur/source/test.py
+++ b/kukur/source/test.py
@@ -8,7 +8,7 @@ This takes care to not persistently store metadata."""
 import logging
 
 from datetime import datetime, timezone
-from typing import Any, Generator
+from typing import Any, Generator, List
 
 from dateutil.tz import tzlocal
 
@@ -18,7 +18,7 @@ from kukur import Metadata, SeriesSearch, SeriesSelector, Source
 logger = logging.getLogger(__name__)
 
 
-def search(source: Source, source_name: str) -> Generator[list[Any], None, None]:
+def search(source: Source, source_name: str) -> Generator[List[Any], None, None]:
     """Test listing all series (or metadata) in a source."""
     header_printed = False
     logger.info('Searching for time series in "%s"', source_name)
@@ -37,7 +37,7 @@ def search(source: Source, source_name: str) -> Generator[list[Any], None, None]
 
 def metadata(
     source: Source, source_name: str, series_name: str
-) -> Generator[list[Any], None, None]:
+) -> Generator[List[Any], None, None]:
     """Test fetching metadata from a source.
 
     This does not store the metadata."""
@@ -53,7 +53,7 @@ def data(
     series_name: str,
     start_date: datetime,
     end_date: datetime,
-) -> Generator[list[Any], None, None]:
+) -> Generator[List[Any], None, None]:
     """Test fetching data for a time series."""
     start_date = _make_aware(start_date)
     end_date = _make_aware(end_date)
@@ -78,11 +78,11 @@ def data(
             yield [ts.as_py().isoformat(), value.as_py()]
 
 
-def _get_metadata_header(result: Metadata) -> list[str]:
+def _get_metadata_header(result: Metadata) -> List[str]:
     return ["series name"] + [k for k, _ in result.iter_serialized()]
 
 
-def _get_metadata(result: Metadata) -> list[Any]:
+def _get_metadata(result: Metadata) -> List[Any]:
     return [result.series.tags["series name"]] + [
         v for _, v in result.iter_serialized()
     ]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         "odbc": ["pyodbc"],
         "piwebapi": ["requests", "requests-kerberos"],
     },
-    python_requires='>=3.9',
+    python_requires='>=3.8',
     package_data={
         'kukur': ['py.typed'],
     },

--- a/tests/source/test_csv.py
+++ b/tests/source/test_csv.py
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: 2021 Timeseer.AI
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Dict
+
 from dateutil.parser import parse as parse_date
 
 import kukur.config
@@ -27,7 +29,7 @@ def get_source(source_name: str) -> Source:
 
 
 def make_series(
-    source: str, tags: dict[str, str] = {"series name": "test-tag-1"}
+    source: str, tags: Dict[str, str] = {"series name": "test-tag-1"}
 ) -> SeriesSelector:
     return SeriesSelector.from_tags(source, tags)
 

--- a/tests/source/test_delta.py
+++ b/tests/source/test_delta.py
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: 2022 Timeseer.AI
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Dict
+
 from dateutil.parser import parse as parse_date
 
 import kukur.config
@@ -24,7 +26,7 @@ def get_source(source_name: str) -> Source:
 
 
 def make_series(
-    source: str, tags: dict[str, str] = {"series name": "test-tag-1"}
+    source: str, tags: Dict[str, str] = {"series name": "test-tag-1"}
 ) -> SeriesSelector:
     return SeriesSelector.from_tags(source, tags)
 

--- a/tests/source/test_feather.py
+++ b/tests/source/test_feather.py
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: 2021 Timeseer.AI
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Dict
+
 from dateutil.parser import parse as parse_date
 
 import kukur.config
@@ -24,7 +26,7 @@ def get_source(source_name: str) -> Source:
 
 
 def make_series(
-    source: str, tags: dict[str, str] = {"series name": "test-tag-1"}
+    source: str, tags: Dict[str, str] = {"series name": "test-tag-1"}
 ) -> SeriesSelector:
     return SeriesSelector.from_tags(source, tags)
 

--- a/tests/source/test_parquet.py
+++ b/tests/source/test_parquet.py
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: 2021 Timeseer.AI
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Dict
+
 from dateutil.parser import parse as parse_date
 
 import kukur.config
@@ -24,7 +26,7 @@ def get_source(source_name: str) -> Source:
 
 
 def make_series(
-    source: str, tags: dict[str, str] = {"series name": "test-tag-1"}
+    source: str, tags: Dict[str, str] = {"series name": "test-tag-1"}
 ) -> SeriesSelector:
     return SeriesSelector.from_tags(source, tags)
 


### PR DESCRIPTION
Stable Databricks has 3.8 as its latest version right now.