### PR TITLE
Remove the unnecessary assert on series name when searching.

### DIFF
--- a/kukur/flight.py
+++ b/kukur/flight.py
@@ -81,11 +81,9 @@ class KukurFlightServer:
         selector = SeriesSelector.from_data(request)
         for result in self.__source.search(selector):
             if isinstance(result, Metadata):
-                assert "series name" in result.series.tags
                 metadata = result.to_data()
                 yield json.dumps(metadata).encode()
             else:
-                assert "series name" in result.tags
                 series = {
                     "source": result.source,
                     "tags": result.tags,


### PR DESCRIPTION
A series does not necessarily need a series name in its structure.