### PR TITLE
Always return Metadata for ADX sources

### DIFF
--- a/kukur/source/azure_data_explorer/azure_data_explorer.py
+++ b/kukur/source/azure_data_explorer/azure_data_explorer.py
@@ -3,11 +3,11 @@
 # SPDX-FileCopyrightText: 2022 Timeseer.AI
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass
 import json
 
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, Generator, List, Optional, Union
+from typing import Any, Dict, Generator, List, Optional
 
 import pyarrow as pa
 
@@ -134,9 +134,7 @@ class DataExplorerSource:  # pylint: disable=too-many-instance-attributes
         )
         self.__client = KustoClient(kcsb)
 
-    def search(
-        self, selector: SeriesSearch
-    ) -> Generator[Union[Metadata, SeriesSelector], None, None]:
+    def search(self, selector: SeriesSearch) -> Generator[Metadata, None, None]:
         """Search for series matching the given selector."""
         if len(self.__tags) == 0:
             raise KukurException("Define tags to support listing time series")
@@ -161,7 +159,7 @@ class DataExplorerSource:  # pylint: disable=too-many-instance-attributes
                 for tag in self.__tags:
                     tags[tag] = row[tag]
                 for field in fields:
-                    yield SeriesSelector(selector.source, tags, field)
+                    yield Metadata(SeriesSelector(selector.source, tags, field))
         else:
             summaries = [
                 f"['{name}']=arg_max(['{self.__timestamp_column}'], ['{name}'])"

--- a/tests/source/test_azure_data_explorer.py
+++ b/tests/source/test_azure_data_explorer.py
@@ -1,13 +1,16 @@
+# SPDX-FileCopyrightText: 2022 Timeseer.AI
+# SPDX-License-Identifier: Apache-2.0
+
 from datetime import datetime, timedelta
 from random import random
 from typing import Any, Dict, List, Union
-from kukur.metadata import Metadata
-
-from kukur.source.azure_data_explorer import from_config
-from kukur import SeriesSelector
-from kukur.source.metadata import MetadataMapper, MetadataValueMapper
 
 from unittest.mock import patch
+
+from kukur import SeriesSelector
+from kukur.metadata import Metadata
+from kukur.source.azure_data_explorer import from_config
+from kukur.source.metadata import MetadataMapper, MetadataValueMapper
 
 
 class MockKustoResponse:
@@ -193,5 +196,10 @@ def test_search_without_metadata(_kusto_client) -> None:
         None,
     )
     selector = SeriesSelector("my_source", {}, "pressure")
-    series = list(source.search(selector))
-    assert len(series) == 6
+    metadata_list = list(source.search(selector))
+    assert len(metadata_list) == 6
+    for metadata in metadata_list:
+        assert isinstance(metadata, Metadata)
+        assert "deviceId" in metadata.series.tags
+        assert "plant" in metadata.series.tags
+        assert "location" in metadata.series.tags


### PR DESCRIPTION
Returning a SeriesSelector signals that a separate query for metadata will give different results.

This closes #135.