### PR TITLE
Fix returning metadata for series without a name

### DIFF
--- a/kukur/source/__init__.py
+++ b/kukur/source/__init__.py
@@ -172,8 +172,6 @@ class SourceWrapper:
         The resulting metadata is the combination of the metadata in the source itself and any additional
         metadata sources. Metadata sources earlier in the list of sources take precendence over later ones."""
         metadata = Metadata(selector)
-        if "series name" not in selector.tags:
-            return metadata
         for metadata_source in list(reversed(self.__metadata)) + [
             MetadataSource(self.__source.metadata)
         ]:

--- a/kukur/source/integration_test/integration_test_source.py
+++ b/kukur/source/integration_test/integration_test_source.py
@@ -26,11 +26,18 @@ class IntegrationTestSource:
             SeriesSelector(
                 selector.source, {"tag1": "value1a", "tag2": "value2a"}, "temperature"
             ),
-            {Description: "integration test"},
+            {Description: "integration test temperature"},
         )
 
-    def get_metadata(self, selector: SeriesSelector) -> Metadata:
+    def get_metadata(  # pylint: disable=no-self-use
+        self, selector: SeriesSelector
+    ) -> Metadata:
         """Get metadata from the Flight service."""
+        if selector == SeriesSelector(
+            selector.source, {"tag1": "value1", "tag2": "value2"}, "pressure"
+        ):
+            return Metadata(selector, {Description: "integration test pressure"})
+        return Metadata(selector)
 
     def get_data(
         self, selector: SeriesSelector, start_date: datetime, end_date: datetime

--- a/tests/integration/test_flight.py
+++ b/tests/integration/test_flight.py
@@ -133,19 +133,7 @@ def test_metadata_backwards_compatibility(client: Client):
     assert dictionary.mapping[1] == "ON"
 
 
-def test_get_source_structure(client: Client):
-    source_structure = client.get_source_structure(
-        SeriesSelector(suffix_source("noaa")),
-    )
-    assert len(source_structure.tag_keys) == 2
-    assert "location" in source_structure.tag_keys
-    assert len(source_structure.tag_values) == 5
-    assert {"key": "location", "value": "coyote_creek"} in source_structure.tag_values
-    assert len(source_structure.fields) == 6
-    assert "degrees" in source_structure.fields
-
-
-def test_series_without_series_name(client: Client):
+def test_search_series_without_series_name(client: Client):
     series = list(client.search(SeriesSearch("integration-test")))
     assert len(series) == 2
     assert isinstance(series[0], SeriesSelector)
@@ -154,4 +142,13 @@ def test_series_without_series_name(client: Client):
     assert isinstance(series[1], Metadata)
     assert series[1].series.tags == {"tag1": "value1a", "tag2": "value2a"}
     assert series[1].series.field == "temperature"
-    assert series[1].get_field_by_name("description") == "integration test"
+    assert series[1].get_field_by_name("description") == "integration test temperature"
+
+
+def test_series_metadata_without_series_name(client: Client):
+    metadata = client.get_metadata(
+        SeriesSelector(
+            "integration-test", {"tag1": "value1", "tag2": "value2"}, "pressure"
+        )
+    )
+    assert metadata.get_field_by_name("description") == "integration test pressure"


### PR DESCRIPTION
This removes one redundant test from the flight test, as the exact same test is done in the InfluxDB tests and it does not work when not running in Docker.