### PR TITLE
Unneeded series names

### DIFF
--- a/kukur/source/__init__.py
+++ b/kukur/source/__init__.py
@@ -149,11 +149,7 @@ class SourceWrapper:
         if results is None:
             return
         for result in results:
-            if (
-                len(self.__metadata) == 0
-                or isinstance(result, SeriesSelector)
-                or "series name" not in result.series.tags
-            ):
+            if len(self.__metadata) == 0 or isinstance(result, SeriesSelector):
                 yield result
             else:
                 extra_metadata = self.get_metadata(

--- a/kukur/source/integration_test/integration_test_source.py
+++ b/kukur/source/integration_test/integration_test_source.py
@@ -9,7 +9,7 @@ from typing import Generator, Union
 from pyarrow import Table
 
 from kukur import Metadata, SeriesSearch, SeriesSelector
-from kukur.metadata.fields import Description
+from kukur.metadata.fields import Description, Unit
 
 
 class IntegrationTestSource:
@@ -37,6 +37,10 @@ class IntegrationTestSource:
             selector.source, {"tag1": "value1", "tag2": "value2"}, "pressure"
         ):
             return Metadata(selector, {Description: "integration test pressure"})
+        if selector == SeriesSelector(
+            selector.source, {"tag1": "value1a", "tag2": "value2a"}, "temperature"
+        ):
+            return Metadata(selector, {Unit: "c"})
         return Metadata(selector)
 
     def get_data(

--- a/kukur/source/kukur/kukur.py
+++ b/kukur/source/kukur/kukur.py
@@ -1,7 +1,8 @@
 """Connect to another Kukur instance using Arrow Flight."""
+
 # SPDX-FileCopyrightText: 2021 Timeseer.AI
-#
 # SPDX-License-Identifier: Apache-2.0
+
 from datetime import datetime
 from typing import Any, Dict, Generator, Optional, Tuple, Union
 
@@ -9,7 +10,6 @@ import pyarrow as pa
 
 from kukur import Metadata, SeriesSearch, SeriesSelector, SourceStructure
 from kukur.client import Client
-from kukur.exceptions import InvalidDataError
 
 
 def from_config(config: Dict[str, Any]):
@@ -52,8 +52,6 @@ class KukurSource:
 
     def get_metadata(self, selector: SeriesSelector) -> Metadata:
         """Get metadata from the Flight service."""
-        if "series name" not in selector.tags:
-            raise InvalidDataError("No series name")
         remote_selector = SeriesSelector.from_tags(
             self.__source_name, selector.tags, selector.field
         )

--- a/tests/integration/test_flight.py
+++ b/tests/integration/test_flight.py
@@ -110,7 +110,7 @@ def test_plot_data_fallback(client: Client):
 
 def test_sources(client: Client):
     data = client.list_sources()
-    assert len(data) == 49
+    assert len(data) == 50
     assert "sql" in data
     assert "row" in data
     assert "noaa" in data
@@ -137,6 +137,15 @@ def test_search_series_without_series_name(client: Client):
     assert series[1].series.tags == {"tag1": "value1a", "tag2": "value2a"}
     assert series[1].series.field == "temperature"
     assert series[1].get_field_by_name("description") == "integration test temperature"
+
+
+def test_series_search_without_series_name_and_extra_metadata(client: Client):
+    series = list(client.search(SeriesSearch("integration-test-extra-metadata")))
+    assert len(series) == 2
+    assert isinstance(series[1], Metadata)
+    assert series[1].series.tags == {"tag1": "value1a", "tag2": "value2a"}
+    assert series[1].series.field == "temperature"
+    assert series[1].get_field_by_name("unit") == "c"
 
 
 def test_series_metadata_without_series_name(client: Client):

--- a/tests/integration/test_flight.py
+++ b/tests/integration/test_flight.py
@@ -2,7 +2,8 @@
 
 They use the client to request data."""
 
-import os
+# SPDX-FileCopyrightText: 2022 Timeseer.AI
+# SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
 
@@ -18,13 +19,6 @@ def client() -> Client:
     kukur_client = Client()
     kukur_client._get_client().wait_for_available(timeout=10)
     return kukur_client
-
-
-def suffix_source(source_name: str) -> str:
-    if "KUKUR_INTEGRATION_TARGET" in os.environ:
-        target = os.environ["KUKUR_INTEGRATION_TARGET"]
-        return f"{source_name}-{target}"
-    return source_name  # works in docker container
 
 
 def test_search(client: Client):
@@ -116,7 +110,7 @@ def test_plot_data_fallback(client: Client):
 
 def test_sources(client: Client):
     data = client.list_sources()
-    assert len(data) == 48
+    assert len(data) == 49
     assert "sql" in data
     assert "row" in data
     assert "noaa" in data

--- a/tests/integration/test_influxdb.py
+++ b/tests/integration/test_influxdb.py
@@ -2,6 +2,9 @@
 
 They use the client to request data."""
 
+# SPDX-FileCopyrightText: 2022 Timeseer.AI
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 
 from datetime import datetime

--- a/tests/integration/test_kukur.py
+++ b/tests/integration/test_kukur.py
@@ -1,0 +1,24 @@
+"""Integration test for Kukur sources."""
+
+# SPDX-FileCopyrightText: 2022 Timeseer.AI
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from kukur import Client, SeriesSelector
+
+
+@pytest.fixture
+def client() -> Client:
+    kukur_client = Client()
+    kukur_client._get_client().wait_for_available(timeout=10)
+    return kukur_client
+
+
+def test_series_metadata_without_series_name(client: Client):
+    metadata = client.get_metadata(
+        SeriesSelector(
+            "kukur-integration-test", {"tag1": "value1", "tag2": "value2"}, "pressure"
+        )
+    )
+    assert metadata.get_field_by_name("description") == "integration test pressure"

--- a/tests/integration/test_odbc.py
+++ b/tests/integration/test_odbc.py
@@ -2,6 +2,9 @@
 
 They use the client to request data."""
 
+# SPDX-FileCopyrightText: 2022 Timeseer.AI
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import os
 

--- a/tests/test_data/integration-test/integration-test-source.toml
+++ b/tests/test_data/integration-test/integration-test-source.toml
@@ -1,2 +1,9 @@
 [source.integration-test]
 type = "integration-test"
+
+[source.integration-test-extra-metadata]
+type = "integration-test"
+metadata_sources = ["integration-test"]
+
+[metadata.integration-test]
+type = "integration-test"

--- a/tests/test_data/kukur/kukur-integration-test-source.toml
+++ b/tests/test_data/kukur/kukur-integration-test-source.toml
@@ -1,0 +1,3 @@
+[source.kukur-integration-test]
+type = "kukur"
+source = "integration-test"


### PR DESCRIPTION
This fixes two other issues for series that lack a series name tag:
- the Kukur source was failing in that case
- extra metadata was not fetched for a series with series name returned from a source that returns a selector.