### PR TITLE
Change exception handling during metadata search

### DIFF
--- a/kukur/source/__init__.py
+++ b/kukur/source/__init__.py
@@ -159,18 +159,17 @@ class SourceWrapper:
                 )
                 try:
                     extra_metadata = self.get_metadata(series_selector)
+                    for k, v in result.iter_names():
+                        if v is not None and v != "":
+                            extra_metadata.set_field_by_name(k, v)
+                    yield extra_metadata
                 except Exception:  # pylint: disable=broad-except
                     logger.error(
                         """Metadata query for "%s" (%s) failed all attempts.""",
                         series_selector.name,
                         series_selector.source,
                     )
-                    yield series_selector
-
-                for k, v in result.iter_names():
-                    if v is not None and v != "":
-                        extra_metadata.set_field_by_name(k, v)
-                yield extra_metadata
+                    yield result
 
     def get_metadata(self, selector: SeriesSelector) -> Metadata:
         """Return the metadata for the given series.

--- a/kukur/source/__init__.py
+++ b/kukur/source/__init__.py
@@ -154,11 +154,19 @@ class SourceWrapper:
             if len(self.__metadata) == 0 or isinstance(result, SeriesSelector):
                 yield result
             else:
-                extra_metadata = self.get_metadata(
-                    SeriesSelector.from_tags(
-                        result.series.source, result.series.tags, result.series.field
-                    )
+                series_selector = SeriesSelector.from_tags(
+                    result.series.source, result.series.tags, result.series.field
                 )
+                try:
+                    extra_metadata = self.get_metadata(series_selector)
+                except Exception:  # pylint: disable=broad-except
+                    logger.error(
+                        """Metadata query for "%s" (%s) failed all attempts.""",
+                        series_selector.name,
+                        series_selector.source,
+                    )
+                    yield series_selector
+
                 for k, v in result.iter_names():
                     if v is not None and v != "":
                         extra_metadata.set_field_by_name(k, v)
@@ -174,21 +182,13 @@ class SourceWrapper:
             MetadataSource(self.__source.metadata)
         ]:
             query_fn = functools.partial(metadata_source.source.get_metadata, selector)
-            try:
-                received_metadata = _retry(
-                    self.__query_retry_count,
-                    self.__query_retry_delay,
-                    query_fn,
-                    f'Metadata query for "{selector.name}" ({selector.source}) failed',
-                )
-            except Exception:  # pylint: disable=broad-except
-                logger.error(
-                    """Metadata query for "%s" (%s) failed all attempts, returning empty metadata.""",
-                    selector.name,
-                    selector.source,
-                )
-                received_metadata = Metadata(selector)
 
+            received_metadata = _retry(
+                self.__query_retry_count,
+                self.__query_retry_delay,
+                query_fn,
+                f'Metadata query for "{selector.name}" ({selector.source}) failed',
+            )
             if len(metadata_source.fields) == 0:
                 for k, v in received_metadata.iter_names():
                     if v is not None and v != "":

--- a/kukur/source/integration_test/integration_test_source.py
+++ b/kukur/source/integration_test/integration_test_source.py
@@ -9,6 +9,7 @@ from typing import Generator, Union
 from pyarrow import Table
 
 from kukur import Metadata, SeriesSearch, SeriesSelector
+from kukur.exceptions import InvalidDataError
 from kukur.metadata.fields import Description, Unit
 
 
@@ -28,6 +29,12 @@ class IntegrationTestSource:
             ),
             {Description: "integration test temperature"},
         )
+        yield Metadata(
+            SeriesSelector(
+                selector.source, {"tag1": "value1b", "tag2": "value2b"}, "pH"
+            ),
+            {Description: "integration test pH"},
+        )
 
     def get_metadata(  # pylint: disable=no-self-use
         self, selector: SeriesSelector
@@ -41,6 +48,10 @@ class IntegrationTestSource:
             selector.source, {"tag1": "value1a", "tag2": "value2a"}, "temperature"
         ):
             return Metadata(selector, {Unit: "c"})
+        if selector == SeriesSelector(
+            selector.source, {"tag1": "value1b", "tag2": "value2b"}, "pH"
+        ):
+            raise InvalidDataError("Metadata not found")
         return Metadata(selector)
 
     def get_data(


### PR DESCRIPTION
The search method does not fail if metadata search fails for any of the resulting series, returning a SeriesSelector instead. The get_metadata method will raise an exception if it cannot fetch metadata.