### PR TITLE
Allow not setting a query timeout

### DIFF
--- a/docs/source/adodb.asciidoc
+++ b/docs/source/adodb.asciidoc
@@ -20,6 +20,7 @@ type = "adodb"
 connection_string = "<ADODB connection_string>"
 connection_string_path = "<path to connection string>"
 query_timeout_seconds = 0
+query_timeout_enable = true
 query_string_parameters = false
 list_query = "<query to list all time series in a source>"
 list_query_path = "<path to list_query>"
@@ -66,9 +67,12 @@ In that case use `{}` to format parameters into queries.
 In queries with multiple parameters, the order can be changed by using the argument position: `{1} {2} {0}`.
 Use a read-only connection with a minimal amount of privileges as https://owasp.org/www-community/attacks/SQL_Injection[SQL Injection] are possible in that case and cannot be prevented by Kukur.
 
-`query_timeout_seconds` defines the timeout on a query. 
-Default is 0, 
+`query_timeout_seconds` defines the timeout on a query.
+Default is 0,
 no timeout.
+
+Some drivers do not allow setting a timeout.
+Disable it using `query_timeout_enable = false`.
 
 === Search
 

--- a/docs/source/odbc.asciidoc
+++ b/docs/source/odbc.asciidoc
@@ -15,6 +15,7 @@ type = "odbc"
 connection_string = "<ODBC connection_string>"
 connection_string_path = "<path to connection string>"
 query_timeout_seconds = 0
+query_timeout_enable = true
 query_string_parameters = false
 list_query = "<query to list all time series in a source>"
 list_query_path = "<path to list_query>"
@@ -82,9 +83,12 @@ In queries with multiple parameters, the order can be changed by using the argum
 Use a read-only connection with a minimal amount of privileges as https://owasp.org/www-community/attacks/SQL_Injection[SQL Injection] are possible in that case and cannot be prevented by Kukur.
 
 
-`query_timeout_seconds` defines the timeout on a query. 
-Default is 0, 
+`query_timeout_seconds` defines the timeout on a query.
+Default is 0,
 no timeout.
+
+Some drivers do not allow setting a timeout.
+Disable it using `query_timeout_enable = false`.
 
 === Search
 

--- a/kukur/source/adodb/adodb.py
+++ b/kukur/source/adodb/adodb.py
@@ -49,7 +49,9 @@ class ADODBSource(BaseSQLSource):
 
     def connect(self):
         """Return an ADODB connection."""
-        return adodbapi.connect(
-            self._config.connection_string,
-            {"timeout": self._config.query_timeout_seconds},
-        )
+        if self._config.query_timeout_seconds is not None:
+            return adodbapi.connect(
+                self._config.connection_string,
+                {"timeout": self._config.query_timeout_seconds},
+            )
+        return adodbapi.connect(self._config.connection_string)

--- a/kukur/source/odbc/odbc.py
+++ b/kukur/source/odbc/odbc.py
@@ -44,5 +44,6 @@ class ODBCSource(BaseSQLSource):
     def connect(self):
         """Return a pyodbc connection."""
         connection = pyodbc.connect(self._config.connection_string)
-        connection.timeout = self._config.query_timeout_seconds
+        if self._config.query_timeout_seconds is not None:
+            connection.timeout = self._config.query_timeout_seconds
         return connection

--- a/kukur/source/sql.py
+++ b/kukur/source/sql.py
@@ -44,7 +44,7 @@ class SQLConfig:  # pylint: disable=too-many-instance-attributes
     data_timezone: Optional[tzinfo] = None
     data_query_timezone: Optional[tzinfo] = None
     enable_trace_logging: bool = False
-    query_timeout_seconds: int = 0
+    query_timeout_seconds: Optional[int] = None
 
     @classmethod
     def from_dict(cls, data):
@@ -86,7 +86,8 @@ class SQLConfig:  # pylint: disable=too-many-instance-attributes
             )
         if "enable_trace_logging" in data:
             config.enable_trace_logging = data.get("enable_trace_logging", False)
-        config.query_timeout_seconds = data.get("query_timeout_seconds", 0)
+        if data.get("query_timeout_enable", True):
+            config.query_timeout_seconds = data.get("query_timeout_seconds", 0)
 
         return config
 

--- a/kukur/source/sqlite/sqlite.py
+++ b/kukur/source/sqlite/sqlite.py
@@ -30,7 +30,10 @@ class SQLiteSource(BaseSQLSource):
         uri = False
         if self._config.connection_string.startswith("file:"):
             uri = True
-        if self._config.query_timeout_seconds == 0:
+        if (
+            self._config.query_timeout_seconds is None
+            or self._config.query_timeout_seconds == 0
+        ):
             connection = sqlite3.connect(
                 self._config.connection_string,
                 detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,


### PR DESCRIPTION
The Postgres ODBC driver does not allow it.

It's a no-op for SQLite or CrateDB.