### PR TITLE
Allow running integration tests in Docker

### DIFF
--- a/tests/test_data/docker-compose.container.yml
+++ b/tests/test_data/docker-compose.container.yml
@@ -1,0 +1,10 @@
+version: '2.3'
+
+services:
+  kukur:
+    build: ../../.
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./Kukur.toml:/usr/src/app/Kukur.toml
+      - .:/usr/src/app/tests/test_data

--- a/tests/test_data/docker-compose.yml
+++ b/tests/test_data/docker-compose.yml
@@ -33,8 +33,25 @@ services:
     volumes:
       - crate-data:/data
     command: ["crate", "-Cdiscovery.type=single-node"]
+  postgres:
+    image: postgres:15
+    ports:
+      - "5431:5432"
+    environment:
+      - POSTGRES_PASSWORD=Timeseer!AI
+      - PGUSER=postgres
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./postgres/import-data.sql:/docker-entrypoint-initdb.d/import-data.sql
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 5s
+      timeout: 5s
+      retries: 18
+      start_period: 5s
 
 volumes:
     crate-data:
     database-data:
     influx-data:
+    postgres-data:


### PR DESCRIPTION
Now the corresponding instructions in the README work again.