### PR TITLE
Introduce TLSOptions for extra TLS configuration settings

### DIFF
--- a/kukur/__init__.py
+++ b/kukur/__init__.py
@@ -19,7 +19,7 @@ from .base import (
 )
 from .exceptions import KukurException  # noqa
 from .metadata import Metadata
-from .client import Client  # noqa
+from .client import Client, TLSOptions  # noqa
 
 
 @typing.runtime_checkable


### PR DESCRIPTION
This is cleaner than having a keyword argument for every possible setting. Add option to ignore all certificate validation.