### PR TITLE
Migration from Docker Compose v1 to v2  (actions/runner-images#9557)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: docker load < /tmp/kukur.tar
 
       - name: Start integration test compose environment
-        run: docker-compose -f docker-compose-${{ matrix.target }}.container.yml -f docker-compose-${{ matrix.target }}.yml up -d
+        run: docker compose -f docker compose-${{ matrix.target }}.container.yml -f docker compose-${{ matrix.target }}.yml up -d
         working-directory: tests/test_data
 
       - name: Set up Python


### PR DESCRIPTION
  - Docker compose v1 will be removed from Ubuntu & Windows images.
  - Docker compose v1 has been [deprecated](https://docs.docker.com/compose/migrate/) since July 2023