### PR TITLE
Use ParquetReader to reduce memory pressure

### DIFF
--- a/kukur/inspect/adls.py
+++ b/kukur/inspect/adls.py
@@ -9,19 +9,11 @@ from urllib.parse import ParseResult
 
 import pyarrow as pa
 from pyarrow import fs
-from pyarrow.dataset import Dataset
 
 from kukur.exceptions import MissingModuleException
 from kukur.inspect import InspectedPath, InspectOptions, InvalidInspectURI
-from kukur.inspect.arrow import get_data_set
+from kukur.inspect.arrow import BlobResource
 from kukur.inspect.arrow import inspect as inspect_blob
-
-try:
-    from deltalake import DeltaTable
-
-    HAS_DELTA_LAKE = True
-except ImportError:
-    HAS_DELTA_LAKE = False
 
 try:
     from pyarrow.fs import AzureFileSystem
@@ -41,7 +33,8 @@ def preview(
     blob_uri: ParseResult, num_rows: int, options: Optional[InspectOptions]
 ) -> Optional[pa.Table]:
     """Return the first nuw_rows of the blob."""
-    data_set = _get_data_set(blob_uri, options)
+    resource = _get_resource(blob_uri)
+    data_set = resource.get_data_set(options)
     return data_set.head(num_rows, batch_size=num_rows, batch_readahead=1)
 
 
@@ -49,22 +42,14 @@ def read(
     blob_uri: ParseResult, options: Optional[InspectOptions]
 ) -> Generator[pa.RecordBatch, None, None]:
     """Iterate over all RecordBatches at the given URI."""
-    data_set = _get_data_set(blob_uri, options)
-    column_names = None
-    if options is not None:
-        column_names = options.column_names
-    for record_batch in data_set.to_batches(columns=column_names, batch_readahead=1):
-        yield record_batch
+    resource = _get_resource(blob_uri)
+    for batch in resource.read_batches(options):
+        yield batch
 
 
-def _get_data_set(blob_uri: ParseResult, options: Optional[InspectOptions]) -> Dataset:
+def _get_resource(blob_uri: ParseResult) -> BlobResource:
     filesystem, blob_path = _get_filesystem_path(blob_uri)
-    data_set = get_data_set(filesystem, blob_path, options)
-    if data_set is None:
-        if not HAS_DELTA_LAKE:
-            raise MissingModuleException("deltalake")
-        data_set = DeltaTable(blob_uri.geturl()).to_pyarrow_dataset()
-    return data_set
+    return BlobResource(blob_uri.geturl(), filesystem, blob_path)
 
 
 def _get_filesystem_path(blob_uri: ParseResult) -> Tuple[fs.FileSystem, PurePath]:

--- a/kukur/inspect/adls.py
+++ b/kukur/inspect/adls.py
@@ -43,8 +43,7 @@ def read(
 ) -> Generator[pa.RecordBatch, None, None]:
     """Iterate over all RecordBatches at the given URI."""
     resource = _get_resource(blob_uri)
-    for batch in resource.read_batches(options):
-        yield batch
+    yield from resource.read_batches(options)
 
 
 def _get_resource(blob_uri: ParseResult) -> BlobResource:

--- a/kukur/inspect/arrow.py
+++ b/kukur/inspect/arrow.py
@@ -59,15 +59,11 @@ class BlobResource:
             stream = self.__fs.open_input_file(str(self.__path))
             rdr = parquet.ParquetFile(stream)
             column_names = _get_column_names(options)
-            for batch in rdr.iter_batches(columns=column_names):
-                yield batch
+            yield from rdr.iter_batches(columns=column_names)
         else:
             data_set = self.get_data_set(options)
             column_names = _get_column_names(options)
-            for record_batch in data_set.to_batches(
-                columns=column_names, batch_readahead=1
-            ):
-                yield record_batch
+            yield from data_set.to_batches(columns=column_names, batch_readahead=1)
 
 
 def _get_column_names(options: Optional[InspectOptions]) -> Optional[List[str]]:

--- a/kukur/inspect/arrow.py
+++ b/kukur/inspect/arrow.py
@@ -4,13 +4,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import PurePath
-from typing import List, Optional
+from typing import Generator, List, Optional
 
-from pyarrow import csv, fs
+from pyarrow import RecordBatch, csv, fs, parquet
 from pyarrow.dataset import CsvFileFormat, Dataset, dataset
 
+from kukur.exceptions import MissingModuleException
 from kukur.inspect import InspectedPath, InspectOptions, ResourceType
 from kukur.source.gpx import parse_gpx
+
+try:
+    from deltalake import DeltaTable
+
+    HAS_DELTA_LAKE = True
+except ImportError:
+    HAS_DELTA_LAKE = False
 
 
 def inspect(filesystem: fs.FileSystem, path: PurePath) -> List[InspectedPath]:
@@ -23,11 +31,57 @@ def inspect(filesystem: fs.FileSystem, path: PurePath) -> List[InspectedPath]:
     return paths
 
 
+class BlobResource:
+    """A blob resource backed by PyArrow."""
+
+    def __init__(self, uri: str, filesystem: fs.FileSystem, path: PurePath):
+        self.__uri = uri
+        self.__fs = filesystem
+        self.__path = path
+
+    def get_data_set(self, options: Optional[InspectOptions]) -> Dataset:
+        """Return a DataSet for the resource."""
+        data_set = get_data_set(self.__fs, self.__path, options)
+        if data_set is None:
+            if not HAS_DELTA_LAKE:
+                raise MissingModuleException("deltalake")
+            data_set = DeltaTable(self.__uri).to_pyarrow_dataset()
+        return data_set
+
+    def read_batches(
+        self, options: Optional[InspectOptions]
+    ) -> Generator[RecordBatch, None, None]:
+        """Iterate over all record batches in a memory-efficient way."""
+        if (
+            get_resource_type_from_extension(self.__path.suffix.lstrip("."))
+            == ResourceType.PARQUET
+        ):
+            stream = self.__fs.open_input_file(str(self.__path))
+            rdr = parquet.ParquetFile(stream)
+            column_names = _get_column_names(options)
+            for batch in rdr.iter_batches(columns=column_names):
+                yield batch
+        else:
+            data_set = self.get_data_set(options)
+            column_names = _get_column_names(options)
+            for record_batch in data_set.to_batches(
+                columns=column_names, batch_readahead=1
+            ):
+                yield record_batch
+
+
+def _get_column_names(options: Optional[InspectOptions]) -> Optional[List[str]]:
+    column_names = None
+    if options is not None and options.column_names is not None:
+        column_names = options.column_names
+    return column_names
+
+
 def get_data_set(
     filesystem: fs.FileSystem, path: PurePath, options: Optional[InspectOptions]
 ) -> Optional[Dataset]:
     """Return a PyArrow dataset for the resources at the given path."""
-    resource_type = _get_resource_type_from_extension(path.suffix.lstrip("."))
+    resource_type = get_resource_type_from_extension(path.suffix.lstrip("."))
     if resource_type in [ResourceType.ARROW, ResourceType.PARQUET, ResourceType.CSV]:
         format = resource_type.value
         if resource_type == ResourceType.CSV and options is not None:
@@ -51,10 +105,11 @@ def _get_resource_type(
             if file_inside.base_name == "_delta_log":
                 return ResourceType.DELTA
         return ResourceType.DIRECTORY
-    return _get_resource_type_from_extension(file_info.extension)
+    return get_resource_type_from_extension(file_info.extension)
 
 
-def _get_resource_type_from_extension(extension: str) -> Optional[ResourceType]:
+def get_resource_type_from_extension(extension: str) -> Optional[ResourceType]:
+    """Return the resource type based on a file extension."""
     if extension == "parquet":
         return ResourceType.PARQUET
     if extension in ["arrow", "feather"]:

--- a/kukur/inspect/filesystem.py
+++ b/kukur/inspect/filesystem.py
@@ -42,5 +42,4 @@ def read_filesystem(
     """
     local = fs.LocalFileSystem()
     resource = BlobResource(str(path), local, path)
-    for batch in resource.read_batches(options):
-        yield batch
+    yield from resource.read_batches(options)

--- a/kukur/inspect/s3.py
+++ b/kukur/inspect/s3.py
@@ -35,8 +35,7 @@ def read(
 ) -> Generator[pa.RecordBatch, None, None]:
     """Iterate over all RecordBatches at the given URI."""
     resource = _get_resource(blob_uri)
-    for batch in resource.read_batches(options):
-        yield batch
+    yield from resource.read_batches(options)
 
 
 def _get_resource(blob_uri: ParseResult) -> BlobResource:

--- a/kukur/inspect/s3.py
+++ b/kukur/inspect/s3.py
@@ -8,20 +8,11 @@ from typing import Generator, List, Optional
 from urllib.parse import ParseResult
 
 import pyarrow as pa
-from pyarrow.dataset import Dataset
 from pyarrow.fs import S3FileSystem
 
-from kukur.exceptions import MissingModuleException
 from kukur.inspect import InspectedPath, InspectOptions, InvalidInspectURI
-from kukur.inspect.arrow import get_data_set
+from kukur.inspect.arrow import BlobResource
 from kukur.inspect.arrow import inspect as inspect_s3
-
-try:
-    from deltalake import DeltaTable
-
-    HAS_DELTA_LAKE = True
-except ImportError:
-    HAS_DELTA_LAKE = False
 
 
 def inspect(blob_uri: ParseResult) -> List[InspectedPath]:
@@ -34,7 +25,8 @@ def preview(
     blob_uri: ParseResult, num_rows: int, options: Optional[InspectOptions]
 ) -> Optional[pa.Table]:
     """Return the first nuw_rows of the blob."""
-    data_set = _get_data_set(blob_uri, options)
+    resource = _get_resource(blob_uri)
+    data_set = resource.get_data_set(options)
     return data_set.head(num_rows, batch_size=num_rows, batch_readahead=1)
 
 
@@ -42,23 +34,15 @@ def read(
     blob_uri: ParseResult, options: Optional[InspectOptions]
 ) -> Generator[pa.RecordBatch, None, None]:
     """Iterate over all RecordBatches at the given URI."""
-    data_set = _get_data_set(blob_uri, options)
-    column_names = None
-    if options is not None:
-        column_names = options.column_names
-    for record_batch in data_set.to_batches(columns=column_names, batch_readahead=1):
-        yield record_batch
+    resource = _get_resource(blob_uri)
+    for batch in resource.read_batches(options):
+        yield batch
 
 
-def _get_data_set(blob_uri: ParseResult, options: Optional[InspectOptions]) -> Dataset:
+def _get_resource(blob_uri: ParseResult) -> BlobResource:
     filesystem = S3FileSystem()
     blob_path = _get_blob_path(blob_uri)
-    data_set = get_data_set(filesystem, blob_path, options)
-    if data_set is None:
-        if not HAS_DELTA_LAKE:
-            raise MissingModuleException("deltalake")
-        data_set = DeltaTable(blob_uri.geturl()).to_pyarrow_dataset()
-    return data_set
+    return BlobResource(blob_uri.geturl(), filesystem, blob_path)
 
 
 def _get_blob_path(blob_uri: ParseResult) -> PurePath:

--- a/tests/inspect/test_filesystem.py
+++ b/tests/inspect/test_filesystem.py
@@ -121,3 +121,10 @@ def test_read_filesystem_csv_no_header_row() -> None:
     assert len(results) == 1
     assert results[0].num_columns == 2
     assert results[0].num_rows == 5
+
+
+def test_read_filesystem_parquet() -> None:
+    path = Path("tests/test_data/parquet/row.parquet")
+    batches = list(read_filesystem(path))
+    assert len(batches) == 1
+    assert len(batches[0]) == 47


### PR DESCRIPTION
On the same 6 GB file, using the data set requires 4.5 GB, the reader requires 500 MB only.