### PR TITLE
Allow providing a subset of tags to the SQL data query

### DIFF
--- a/docs/source/odbc.asciidoc
+++ b/docs/source/odbc.asciidoc
@@ -32,6 +32,7 @@ metadata_value_mapping = "<metadata_value_mapping name>"
 data_query = "<query for data of one series in time range>"
 data_query_path = "<path to data query>"
 data_query_timezone = "<override or specify time zone of timestamps to send a naive timestamp to the odbc driver>"
+data_query_tags = [] # provide only a subset of tags to the data query
 data_timezone = "<override or specify time zone of timestamps returned by the odbc driver>"
 enable_trace_logging = false
 quality_mapping = "<name>"
@@ -292,6 +293,14 @@ select ts, value
 from Data
 where my_location = ? and my_plant = ? and ts >= ? and ts < ?
 """
+```
+
+It is possible to pass only a subset of tags to the data query,
+by using `data_query_tags`.
+
+```toml
+[source.<name>]
+data_query_tags = ["location"]
 ```
 
 If the configuration defines `field_columns`,

--- a/docs/source/postgresql.asciidoc
+++ b/docs/source/postgresql.asciidoc
@@ -41,6 +41,7 @@ metadata_value_mapping = "<metadata_value_mapping name>"
 data_query = "<query for data of one series in time range>"
 data_query_path = "<path to data query>"
 data_query_timezone = "<override or specify time zone of timestamps to send a naive timestamp to the database>"
+data_query_tags = [] # provide only a subset of tags to the data query
 data_timezone = "<override or specify time zone of timestamps returned by the database>"
 enable_trace_logging = false
 quality_mapping = "<name>"
@@ -301,6 +302,14 @@ select ts, value
 from Data
 where my_location = %s and my_plant = %s and ts >= %s and ts < %s
 """
+```
+
+It is possible to pass only a subset of tags to the data query,
+by using `data_query_tags`.
+
+```toml
+[source.<name>]
+data_query_tags = ["location"]
 ```
 
 If the configuration defines `field_columns`,

--- a/docs/source/redshift.asciidoc
+++ b/docs/source/redshift.asciidoc
@@ -46,6 +46,7 @@ metadata_value_mapping = "<metadata_value_mapping name>"
 data_query = "<query for data of one series in time range>"
 data_query_path = "<path to data query>"
 data_query_timezone = "<override or specify time zone of timestamps to send a naive timestamp to the database>"
+data_query_tags = [] # provide only a subset of tags to the data query
 data_timezone = "<override or specify time zone of timestamps returned by the database>"
 enable_trace_logging = false
 quality_mapping = "<name>"
@@ -266,6 +267,14 @@ select ts, value
 from Data
 where my_location = %s and my_plant = %s and ts >= %s and ts < %s
 """
+```
+
+It is possible to pass only a subset of tags to the data query,
+by using `data_query_tags`.
+
+```toml
+[source.<name>]
+data_query_tags = ["location"]
 ```
 
 If the configuration defines `field_columns`,

--- a/docs/source/sqlite.asciidoc
+++ b/docs/source/sqlite.asciidoc
@@ -30,6 +30,7 @@ data_query = "<query for data of one series in time range>"
 data_query_path = "<path to data query>"
 data_query_datetime_format = "<strftime format>"
 data_query_timezone = "<override or specify time zone of timestamps>"
+data_query_tags = [] # provide only a subset of tags to the data query
 data_timezone = "<override or specify time zone of timestamps returned by the data query>"
 enable_trace_logging = false
 quality_mapping = "<name>"
@@ -295,6 +296,14 @@ select ts, value
 from Data
 where my_location = ? and my_plant = ? and ts >= ? and ts < ?
 """
+```
+
+It is possible to pass only a subset of tags to the data query,
+by using `data_query_tags`.
+
+```toml
+[source.<name>]
+data_query_tags = ["location"]
 ```
 
 If the configuration defines `field_columns`,

--- a/kukur/source/sql.py
+++ b/kukur/source/sql.py
@@ -54,6 +54,7 @@ class SQLConfig:  # pylint: disable=too-many-instance-attributes
     data_query_datetime_format: Optional[str] = None
     data_timezone: Optional[tzinfo] = None
     data_query_timezone: Optional[tzinfo] = None
+    data_query_tags: Optional[List[str]] = None
     enable_trace_logging: bool = False
     query_timeout_seconds: Optional[int] = None
     type_checking_row_limit: int = 300
@@ -99,6 +100,7 @@ class SQLConfig:  # pylint: disable=too-many-instance-attributes
             config.data_query_timezone = dateutil.tz.gettz(
                 data.get("data_query_timezone")
             )
+        config.data_query_tags = data.get("data_query_tags")
         if "enable_trace_logging" in data:
             config.enable_trace_logging = data.get("enable_trace_logging", False)
         if data.get("query_timeout_enable", True):
@@ -265,7 +267,12 @@ class BaseSQLSource(ABC):
             query = self._config.data_query.format(field=selector.field)
         except (TypeError, IndexError):
             query = self._config.data_query
-        params = [selector.tags[tag_name] for tag_name in self._config.tag_columns]
+        if self._config.data_query_tags is None:
+            params = [selector.tags[tag_name] for tag_name in self._config.tag_columns]
+        else:
+            params = [
+                selector.tags[tag_name] for tag_name in self._config.data_query_tags
+            ]
         params.extend(
             [
                 self.__format_date(start_date),

--- a/tests/test_data/docker-compose-odbc.yml
+++ b/tests/test_data/docker-compose-odbc.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - database-data:/var/opt/mssql
     healthcheck:
-      test: /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$${SA_PASSWORD}" -Q "SELECT 1" -b -o /dev/null
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$${SA_PASSWORD}" -No -Q "SELECT 1" -b -o /dev/null
       interval: 5s
       timeout: 5s
       retries: 18

--- a/tests/test_data/odbc/entrypoint.sh
+++ b/tests/test_data/odbc/entrypoint.sh
@@ -3,7 +3,7 @@
 (
     set -x
     for i in {1..50}; do
-        /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -i setup.sql
+        /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -No -i setup.sql
         if [ $? -eq 0 ]; then
             break
         else


### PR DESCRIPTION
Sometimes tags are chosen to be purely presentational. The subset of tags that do have business meaning can be selected with this new configuration option.