### PR TITLE
Add a default timeout of 60s to PI Web API requests

### DIFF
--- a/docs/source/piwebapi-da.asciidoc
+++ b/docs/source/piwebapi-da.asciidoc
@@ -11,6 +11,7 @@ type = "piwebapi-da"
 data_archive_uri = "The self-URI of the DataServer"
 max_returned_items_per_call = 150000
 verify_ssl = true
+timeout_seconds = 60 # The maximum time to wait for a response
 username = "" # optional: username for basic authentication
 password = "" # optional: password for basic authentication
 ```
@@ -58,6 +59,9 @@ will have 86400 values per day.
 This means a safe value of `data_query_interval_seconds` is `86400` when the default limit of `150000` is in place in PI Web API.
 For a time series that is being recorded at 1 value per minute and can have 44640 values per month,
 `data_query_interval_seconds = 2678400` is a safe value.
+
+Increase `timeout_seconds` when responses could take longer than the already long 2 minutes.
+Use with `query_retry_count` and `query_retry_delay` to work around flaky connections.
 
 Set `verify_ssl` to `false` when PI Web API uses a self-signed certificate.
 

--- a/kukur/source/piwebapi_da/piwebapi_da.py
+++ b/kukur/source/piwebapi_da/piwebapi_da.py
@@ -45,6 +45,7 @@ from kukur.metadata import fields
 @dataclass
 class _RequestProperties:
     verify_ssl: bool
+    timeout_seconds: float
     max_returned_items_per_call: int
 
 
@@ -76,6 +77,7 @@ class _DictionaryLookup:  # pylint: disable=too-few-public-methods
         response = self.__session.get(
             self.__digital_set_links[name],
             verify=self.__request_properties.verify_ssl,
+            timeout=self.__request_properties.timeout_seconds,
             params=dict(maxCount=self.__request_properties.max_returned_items_per_call),
         )
         response.raise_for_status()
@@ -90,6 +92,7 @@ class _DictionaryLookup:  # pylint: disable=too-few-public-methods
         response = self.__session.get(
             self.__data_archive["Links"]["EnumerationSets"],
             verify=self.__request_properties.verify_ssl,
+            timeout=self.__request_properties.timeout_seconds,
             params=dict(maxCount=self.__request_properties.max_returned_items_per_call),
         )
         response.raise_for_status()
@@ -106,6 +109,7 @@ class PIWebAPIDataArchiveSource:
     def __init__(self, config: Dict):
         self.__request_properties = _RequestProperties(
             verify_ssl=config.get("verify_ssl", True),
+            timeout_seconds=config.get("timeout_seconds", 60),
             max_returned_items_per_call=config.get(
                 "max_returned_items_per_call", 150000
             ),
@@ -126,6 +130,7 @@ class PIWebAPIDataArchiveSource:
         response = session.get(
             self.__data_archive_uri,
             verify=self.__request_properties.verify_ssl,
+            timeout=self.__request_properties.timeout_seconds,
             params=dict(selectedFields="Links.Points;Links.EnumerationSets"),
         )
         response.raise_for_status()
@@ -141,6 +146,7 @@ class PIWebAPIDataArchiveSource:
             response = session.get(
                 data_archive["Links"]["Points"],
                 verify=self.__request_properties.verify_ssl,
+                timeout=self.__request_properties.timeout_seconds,
                 params=dict(
                     maxCount=self.__request_properties.max_returned_items_per_call,
                     startIndex=page
@@ -168,6 +174,7 @@ class PIWebAPIDataArchiveSource:
         response = session.get(
             self.__data_archive_uri,
             verify=self.__request_properties.verify_ssl,
+            timeout=self.__request_properties.timeout_seconds,
             params=dict(selectedFields="Links.Points;Links.EnumerationSets"),
         )
         response.raise_for_status()
@@ -176,6 +183,7 @@ class PIWebAPIDataArchiveSource:
         response = session.get(
             data_archive["Links"]["Points"],
             verify=self.__request_properties.verify_ssl,
+            timeout=self.__request_properties.timeout_seconds,
             params=dict(nameFilter=selector.name),
         )
         response.raise_for_status()
@@ -208,6 +216,7 @@ class PIWebAPIDataArchiveSource:
             response = session.get(
                 data_url,
                 verify=self.__request_properties.verify_ssl,
+                timeout=self.__request_properties.timeout_seconds,
                 params=dict(
                     maxCount=str(self.__request_properties.max_returned_items_per_call),
                     startTime=start_date.isoformat(),
@@ -264,6 +273,7 @@ class PIWebAPIDataArchiveSource:
         response = session.get(
             self.__data_archive_uri,
             verify=self.__request_properties.verify_ssl,
+            timeout=self.__request_properties.timeout_seconds,
             params=dict(selectedFields="Links.Points"),
         )
         response.raise_for_status()
@@ -272,6 +282,7 @@ class PIWebAPIDataArchiveSource:
         response = session.get(
             data_archive["Links"]["Points"],
             verify=self.__request_properties.verify_ssl,
+            timeout=self.__request_properties.timeout_seconds,
             params=dict(
                 maxCount=str(self.__request_properties.max_returned_items_per_call),
                 nameFilter=selector.name,


### PR DESCRIPTION
This prevents connections being stuck forever.