### PR TITLE
Use a generic path in the ODBC documentation

### DIFF
--- a/docs/source/odbc.asciidoc
+++ b/docs/source/odbc.asciidoc
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2021 Timeseer.AI
-//
 // SPDX-License-Identifier: Apache-2.0
+
 == ODBC
 
 Sources with `type = "odbc"` configure ODBC sources.
@@ -73,7 +73,7 @@ connection_string = "DSN=kukur;UID=sa;PWD=Kukur!AI"
 or
 
 ```toml
-connection_string = "Driver={/usr/lib/libtdsodbc.so};Server=localhost;Port=1433;Database=TestData;UID=sa;PWD=Kukur!AI"
+connection_string = "Driver={/path/to/driver};Server=localhost;Port=1433;Database=TestData;UID=sa;PWD=Kukur!AI"
 ```
 
 Alternatively, `connection_string_path` can point to a file that contains the connection string.


### PR DESCRIPTION
The driver path is different in different distributions.