### PR TITLE
Support semicolons as a column separator in CSV metadata requests

### DIFF
--- a/kukur/source/csv/csv.py
+++ b/kukur/source/csv/csv.py
@@ -191,7 +191,12 @@ class CSVSource:
             return metadata
 
         with self.__loaders.metadata.open() as metadata_file:
-            reader = csv.DictReader(metadata_file)
+            if self.__options.data_column_separator is not None:
+                reader = csv.DictReader(
+                    metadata_file, delimiter=self.__options.data_column_separator
+                )
+            else:
+                reader = csv.DictReader(metadata_file)
             for row in reader:
                 skip_row = False
                 for tag in self.__options.tags:

--- a/tests/source/test_csv.py
+++ b/tests/source/test_csv.py
@@ -453,6 +453,14 @@ def test_dir_semicolon_separator_search() -> None:
     assert len(many_series) == 2
 
 
+def test_dir_semicolon_separator_metadata() -> None:
+    metadata = get_source("dir_semicolon_separator").get_metadata(
+        SeriesSelector("dir_semicolon_separator", "test-tag-1")
+    )
+
+    assert metadata.get_field(fields.Accuracy) == approx(0.1)
+
+
 def test_dir_semicolon_separator_data() -> None:
     selector = SeriesSelector("dir_semicolon_separator", "test-tag-1")
     data = get_source(selector.source).get_data(selector, START_DATE, END_DATE)


### PR DESCRIPTION
We supported `;` for metadata search, but not for individual metadata requests.