### PR TITLE
The PI AF attribute response can omit items

### DIFF
--- a/kukur/source/piwebapi_af_template/piwebapi_af_template.py
+++ b/kukur/source/piwebapi_af_template/piwebapi_af_template.py
@@ -249,7 +249,7 @@ class PIWebAPIAssetFrameworkTemplateSource:
                 )
 
             attributes = result["GetAttributes"]["Content"]["Items"][i]
-            for attribute in attributes["Content"].get("Items"):
+            for attribute in attributes["Content"].get("Items", []):
                 if self.__config.attribute_names is not None:
                     attribute_path = attribute["Path"].split("|", maxsplit=1)[1]
                     if attribute_path not in self.__config.attribute_names:


### PR DESCRIPTION
Not clear yet why, this needs to be investigated. We should not crash because of it.

This closes #256.