### PR TITLE
Allow PI AF Element Template sources without template

### DIFF
--- a/kukur/source/piwebapi_af_template/piwebapi_af_template.py
+++ b/kukur/source/piwebapi_af_template/piwebapi_af_template.py
@@ -161,7 +161,8 @@ class PIWebAPIAssetFrameworkTemplateSource:
             self.__config.element_template is None
             or self.__config.element_template.strip() == ""
         ):
-            raise InvalidSourceException("element template required")
+            logger.info("Cannot search in element template source without template")
+            return
 
         session = self._get_session()
 

--- a/tests/source/test_piwebapi_af_template.py
+++ b/tests/source/test_piwebapi_af_template.py
@@ -7,7 +7,7 @@ import pytest
 
 from kukur import DataType
 from kukur.base import SeriesSearch
-from kukur.exceptions import InvalidSourceException, KukurException
+from kukur.exceptions import KukurException
 from kukur.source.piwebapi_af_template import from_config
 from kukur.source.piwebapi_af_template.piwebapi_af_template import (
     ElementInOtherDatabaseException,
@@ -705,8 +705,8 @@ def test_search_missing_element_template() -> None:
             "database_uri": DATABASE_URI,
         }
     )
-    with pytest.raises(InvalidSourceException):
-        list(source.search(SeriesSearch("Test")))
+    empty = list(source.search(SeriesSearch("Test")))
+    assert len(empty) == 0
 
 
 @patch("requests.Session.post", side_effect=mocked_requests_post)


### PR DESCRIPTION
These can still be used to fetch data.

This closes timeseer-ai/timeseer#4088.