### PR TITLE
Use read_only flag for loading an excel workbook.

### DIFF
--- a/kukur/source/excel/__init__.py
+++ b/kukur/source/excel/__init__.py
@@ -27,7 +27,7 @@ def parse_excel(readable, sheet_name: str, options: Optional[DataOptions]) -> pa
     if not HAS_OPENPYXL:
         raise MissingModuleException("openpyxl", "excel")
 
-    workbook = openpyxl.load_workbook(readable, data_only=True)
+    workbook = openpyxl.load_workbook(readable, data_only=True, read_only=True)
     worksheet = workbook[sheet_name]
 
     data = list(worksheet.values)
@@ -49,9 +49,10 @@ def list_sheets(readable) -> List[str]:
     """List the sheets in the Excel file."""
     if not HAS_OPENPYXL:
         raise MissingModuleException("openpyxl", "excel")
-
-    workbook = openpyxl.load_workbook(readable)
-    return workbook.sheetnames
+    workbook = openpyxl.load_workbook(readable, read_only=True)
+    sheetnames = workbook.sheetnames
+    workbook.close()
+    return sheetnames
 
 
 def _to_pyarrow(headers: List[str], rows: List[List]) -> pa.Table:


### PR DESCRIPTION
Per the openpyxl documentation the `read_only` flag improves performance and stabilizes the memory consumption. In the used example it went from a 40s load on 1 sheet to a 0.033s load for the same sheet. Memory consumption was equal to the file size used instead of 50x