### PR TITLE
Add a plot data call option for plugin sources.

### DIFF
--- a/docs/source/plugin.asciidoc
+++ b/docs/source/plugin.asciidoc
@@ -10,6 +10,9 @@ Sources with `type = "plugin"` call out to a separate binary that implements all
 type = "plugin"
 cmd = ["/path/to/binary"]
 extra = "foo"
+
+[source.<name>.features]
+plot = false
 ```
 
 `cmd` is a required field.
@@ -17,11 +20,15 @@ All other fields are passed to the binary as provided.
 
 `cmd` can be either a simple string or a list of strings.
 
+`features` is an optional parameter with following option:
+- `plot` when the binary has a separate plot data function defined.
+
 The binary will be called with one extra argument:
 
 - `search` to list time series or metadata
 - `metadata` to get metadata for one time series
 - `data` to return Arrow data
+- `plot` optional argument to return interpolated Arrow data
 
 Input is sent on standard input.
 Output is expected on standard output.
@@ -153,7 +160,7 @@ the binary will receive JSON on standard input.
 
 `"config"` contains the source configuration.
 
-`"metadata"` contains the `"series"` to return metadata for.
+`"data"` contains the `"series"` to return data for.
 
 The `"startDate"` and `"endDate"` fields are formatted per https://datatracker.ietf.org/doc/html/rfc3339#section-5.6[RFC3339].
 
@@ -179,6 +186,44 @@ ifndef::sources[]
 link:sources.asciidoc#Quality[source documentation]
 endif::sources[]
 .
+
+
+=== Plot
+
+When the `plot` feature is enabled a plot argument can be used.
+When called with the `plot` argument,
+the binary will receive JSON on standard input.
+
+```json
+{
+    "config": {},
+    "data": {
+        "series": {
+            "source": "<source name>",
+            "tags": {
+                "tag-1": "tag-1-value",
+                "tag-2": "tag-2-value"
+            },
+            "field": "optional-field"
+        },
+        "startDate": "YYYY-MM-DDTHH:MM:SS+00:00",
+        "endDate": "YYYY-MM-DDTHH:MM:SS+00:00",
+        "intervalCount": 200,
+    }
+}
+```
+
+`"config"` contains the source configuration.
+
+`"data"` contains the `"series"` to return data for.
+
+The `"startDate"` and `"endDate"` fields are formatted per https://datatracker.ietf.org/doc/html/rfc3339#section-5.6[RFC3339].
+
+`"intervalCount"` the number of intervals included in the plot.
+
+The response written to standard output should be in the Apache Arrow https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format[IPC Streaming Format].
+
+The schema of the record batches will be similar to the binary with the `data` argument.
 
 === Example
 

--- a/tests/source/test_plugin.py
+++ b/tests/source/test_plugin.py
@@ -6,13 +6,13 @@
 import sys
 from datetime import datetime
 
-from kukur import Source
+from kukur import PlotSource
 from kukur.base import SeriesSearch, SeriesSelector
 from kukur.metadata import Metadata
 from kukur.source import SourceFactory
 
 
-def get_source() -> Source:
+def get_source() -> PlotSource:
     source = SourceFactory(
         {
             "source": {
@@ -20,6 +20,7 @@ def get_source() -> Source:
                     "type": "plugin",
                     "cmd": [sys.executable, "tests/test_data/plugin/plugin.py"],
                     "quality_mapping": "plugin_quality",
+                    "features": {"plot": True},
                 }
             },
             "quality_mapping": {
@@ -62,4 +63,20 @@ def test_data() -> None:
     assert data["quality"][0].as_py() == 0
     assert data["ts"][1].as_py() == end_date
     assert data["value"][1].as_py() == 42
+    assert data["quality"][1].as_py() == 1
+
+
+def test_plot_data() -> None:
+    source = get_source()
+    start_date = datetime.fromisoformat("2022-01-01T00:00:00+00:00")
+    end_date = datetime.fromisoformat("2022-01-02T00:00:00+00:00")
+    data = source.get_plot_data(
+        SeriesSelector("Plugin", "test"), start_date, end_date, 200
+    )
+    assert len(data) == 2
+    assert data["ts"][0].as_py() == start_date
+    assert data["value"][0].as_py() == 0
+    assert data["quality"][0].as_py() == 0
+    assert data["ts"][1].as_py() == end_date
+    assert data["value"][1].as_py() == 47
     assert data["quality"][1].as_py() == 1

--- a/tests/test_data/plugin/plugin.py
+++ b/tests/test_data/plugin/plugin.py
@@ -18,6 +18,8 @@ def _run() -> None:
         _metadata()
     if sys.argv[1] == "data":
         _data()
+    if sys.argv[1] == "plot":
+        _plot_data()
     sys.exit(0)
 
 
@@ -53,6 +55,18 @@ def _data() -> None:
     end_date = datetime.fromisoformat(query["data"]["endDate"])
     table = Table.from_pydict(
         {"ts": [start_date, end_date], "value": [0, 42], "quality": ["BAD", "GOOD"]}
+    )
+    with ipc.new_stream(sys.stdout.buffer, table.schema) as writer:
+        writer.write_table(table)
+
+
+def _plot_data() -> None:
+    """Return Arrow IPC with that for the time series received on stdin."""
+    query = json.load(sys.stdin)
+    start_date = datetime.fromisoformat(query["data"]["startDate"])
+    end_date = datetime.fromisoformat(query["data"]["endDate"])
+    table = Table.from_pydict(
+        {"ts": [start_date, end_date], "value": [0, 47], "quality": ["BAD", "GOOD"]}
     )
     with ipc.new_stream(sys.stdout.buffer, table.schema) as writer:
         writer.write_table(table)


### PR DESCRIPTION
This will only be enable when the feature `plot` is enabled. Otherwise it will use the data request.