### PR TITLE
Do not retry not implemented errors

### DIFF
--- a/kukur/source/__init__.py
+++ b/kukur/source/__init__.py
@@ -110,6 +110,8 @@ def _retry(retry_count: int, retry_delay: float, data_fn, log_message: str):
     while True:
         try:
             return data_fn()
+        except NotImplementedError as err:
+            raise err
         except Exception as err:  # pylint: disable=broad-except
             retry_count = retry_count - 1
             if retry_count < 0:

--- a/tests/source/test_source_wrapper.py
+++ b/tests/source/test_source_wrapper.py
@@ -111,7 +111,11 @@ class SomeStringTypesSource:
 
 
 class NotImplementedSource:
+    def __init__(self):
+        self.count = 0
+
     def get_metadata(self, selector: SeriesSelector) -> Metadata:
+        self.count = self.count + 1
         raise NotImplementedError()
 
 
@@ -345,6 +349,14 @@ def test_not_implemented_metadata() -> None:
     wrapper = SourceWrapper(Source(source, source), [], {})
     metadata = wrapper.get_metadata(SELECTOR)
     assert metadata is not None
+
+
+def test_not_implemented_metadata_does_not_retry() -> None:
+    source = NotImplementedSource()
+    wrapper = SourceWrapper(Source(source, source), [], {"query_retry_count": 3})
+    metadata = wrapper.get_metadata(SELECTOR)
+    assert metadata is not None
+    assert source.count == 1
 
 
 def _make_source():


### PR DESCRIPTION
The PI AF source does not support fetching metadata. If we use `metadata_sources` together with retries, we would retry all extra metadata lookups.