### PR TITLE
Allow caching authentication tokens

### DIFF
--- a/kukur/source/__init__.py
+++ b/kukur/source/__init__.py
@@ -50,6 +50,11 @@ from kukur.source import (
 from kukur.source import json as json_source
 from kukur.source import kukur as kukur_source
 from kukur.source.quality import QualityMapper
+from kukur.source.token_cache import (
+    InMemoryTokenCacheFactory,
+    TokenCache,
+    TokenCacheFactory,
+)
 
 from .metadata import MetadataMapper, MetadataValueMapper
 
@@ -320,8 +325,12 @@ class SourceFactory:
     __config: dict[str, Any]
     __factory: dict[str, Callable]
 
-    def __init__(self, config):
+    def __init__(self, config: dict, token_cache: TokenCacheFactory | None = None):
         self.__config = config
+
+        if token_cache is None:
+            token_cache = InMemoryTokenCacheFactory()
+        self._token_cache = token_cache
         self.__factory = _FACTORY.copy()
 
     def register_source(
@@ -348,7 +357,9 @@ class SourceFactory:
                     raise InvalidSourceException(
                         f'Source "{name}" has unknown type "{source_type}"'
                     )
-                data_source = self._make_source(source_type, options)
+                data_source = self._make_source(
+                    f"data-{source_name}", source_type, options
+                )
                 return self.make_wrapper(data_source, name, options)
         return None
 
@@ -367,7 +378,9 @@ class SourceFactory:
                 raise InvalidSourceException(
                     f'"Source {source_name}" has unknown metadata type "{metadata_source_type}"'
                 )
-            metadata_source = self._make_source(metadata_source_type, source_config)
+            metadata_source = self._make_source(
+                f"metadata-{source_name}", metadata_source_type, source_config
+            )
 
         extra_metadata = []
         for metadata_source_name in source_config.get("metadata_sources", []):
@@ -392,12 +405,13 @@ class SourceFactory:
                     f'Metadata source "{name}" has unknown type "{source_type}"'
                 )
             metadata_sources[name] = MetadataSource(
-                self._make_source(source_type, options), options.get("fields", [])
+                self._make_source(f"extra-{name}", source_type, options),
+                options.get("fields", []),
             )
         return metadata_sources
 
     def _make_source(
-        self, source_type: str, source_config: dict[str, Any]
+        self, source_id: str, source_type: str, source_config: dict[str, Any]
     ) -> SourceProtocol | TagSource:
         metadata_mapper = self._get_metadata_mapper(
             source_config.get("metadata_mapping")
@@ -417,6 +431,8 @@ class SourceFactory:
                 arguments.append(metadata_value_mapper)
             elif parameter.annotation == QualityMapper:
                 arguments.append(quality_mapper)
+            elif parameter.annotation == TokenCache:
+                arguments.append(self._token_cache.get_cache(source_id))
             else:
                 arguments.append(source_config)
 

--- a/kukur/source/azure_data_explorer/azure_data_explorer.py
+++ b/kukur/source/azure_data_explorer/azure_data_explorer.py
@@ -7,13 +7,15 @@ import logging
 import time
 from collections.abc import Generator
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import pyarrow as pa
 
+from kukur.source.token_cache import Token, TokenCache
+
 try:
-    from azure.identity import DefaultAzureCredential
+    from azure.identity import ClientSecretCredential, DefaultAzureCredential
 
     HAS_AZURE_IDENTITY = True
 except ImportError:
@@ -78,6 +80,7 @@ def from_config(
     config: dict[str, Any],
     metadata_mapper: MetadataMapper,
     metadata_value_mapper: MetadataValueMapper,
+    token_cache: TokenCache,
 ):
     """Create a new Azure Data Explorer data source."""
     connection_string = config["connection_string"]
@@ -108,6 +111,7 @@ def from_config(
         ),
         metadata_mapper,
         metadata_value_mapper,
+        token_cache,
     )
 
 
@@ -124,6 +128,7 @@ class DataExplorerSource:  # pylint: disable=too-many-instance-attributes
         config: DataExplorerConfiguration,
         metadata_mapper: MetadataMapper,
         metadata_value_mapper: MetadataValueMapper,
+        token_cache: TokenCache,
     ):
         if not HAS_AZURE_IDENTITY:
             raise MissingModuleException("azure-identity")
@@ -134,6 +139,7 @@ class DataExplorerSource:  # pylint: disable=too-many-instance-attributes
         self.__metadata_mapper = metadata_mapper
         self.__metadata_value_mapper = metadata_value_mapper
         self.__config = config
+        self.__token_cache = token_cache
         self._sleeper = _Sleeper()
 
     def search(self, selector: SeriesSearch) -> Generator[Metadata, None, None]:
@@ -341,23 +347,28 @@ class DataExplorerSource:  # pylint: disable=too-many-instance-attributes
             and self.__config.client_secret is not None
             and self.__config.tenant_id is not None
         ):
-            kcsb = KustoConnectionStringBuilder.with_aad_application_key_authentication(
-                self.__config.connection_string,
-                self.__config.client_id,
-                self.__config.client_secret,
-                self.__config.tenant_id,
+            azure_credential = ClientSecretCredential(
+                client_id=self.__config.client_id,
+                client_secret=self.__config.client_secret,
+                tenant_id=self.__config.tenant_id,
             )
         else:
             azure_credential = DefaultAzureCredential()
 
-            def _get_token():
-                return azure_credential.get_token(
-                    self.__config.connection_string + "//.default"
-                )[0]
-
-            kcsb = KustoConnectionStringBuilder.with_token_provider(
-                self.__config.connection_string, _get_token
+        def _get_azure_token(_refresh_token):
+            token = azure_credential.get_token(
+                self.__config.connection_string + "//.default"
             )
+            return Token(
+                token.token, datetime.fromtimestamp(token.expires_on, tz=timezone.utc)
+            )
+
+        def _get_token():
+            return self.__token_cache.get_token(_get_azure_token)
+
+        kcsb = KustoConnectionStringBuilder.with_token_provider(
+            self.__config.connection_string, _get_token
+        )
 
         return KustoClient(kcsb)
 

--- a/kukur/source/token_cache.py
+++ b/kukur/source/token_cache.py
@@ -1,0 +1,100 @@
+"""Cache authentications tokens.
+
+Sources can optionally accept a `TokenCache`.
+The `SourceFactory` can be configured with a specific implementation.
+
+The default `TokenCache` keeps tokens in-memory only and is suitable for multithreaded use.
+Other implementations can store tokens on-disk or in shared memory.
+"""
+
+# SPDX-FileCopyrightText: 2026 Timeseer.AI
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Protocol
+
+
+@dataclass
+class Token:
+    """A cached access token."""
+
+    access_token: str
+    expires: datetime | None = None
+    refresh_token: str | None = None
+
+    def is_expired(self) -> bool:
+        """Return True when the token is (about ot be) expired."""
+        now = datetime.now(tz=timezone.utc)
+        if self.expires is None:
+            return True
+        return self.expires < now + timedelta(seconds=30)
+
+
+class TokenCache(Protocol):
+    """Cache access tokens."""
+
+    def get_token(self, token_fn: Callable[[str | None], Token]) -> str:
+        """Retrieve a token.
+
+        Calls `token_fn` when the token is not cached or has expired.
+        A refresh token is provided to the `token_fn` when one is available.
+        """
+
+
+class TokenCacheFactory(Protocol):
+    """Create a `TokenCache` for a source."""
+
+    def get_cache(self, name: str) -> TokenCache:
+        """Return a `TokenCache` for the named source."""
+
+
+class NullTokenCache:
+    """Do not cache any tokens."""
+
+    def get_token(self, token_fn: Callable[[str | None], Token]) -> str:
+        """Retrieve a new token."""
+        return token_fn(None).access_token
+
+
+class InMemoryTokenCache:
+    """Cache OAuth or other tokens for a source.
+
+    This cache keeps tokens in memory and is thread safe.
+    """
+
+    def __init__(self, name: str, lock: threading.Lock, cache: dict[str, Token]):
+        self._name = name
+        self._cache = cache
+        self._lock = lock
+
+    def get_token(self, token_fn: Callable[[str | None], Token]) -> str:
+        """Retrieve a token.
+
+        Calls `token_fn` with a refresh token (if available) when the token expired.
+        """
+        with self._lock:
+            token = self._cache.get(self._name)
+
+            refresh_token = None
+            if token is not None:
+                refresh_token = token.refresh_token
+
+            if token is None or token.is_expired():
+                token = token_fn(refresh_token)
+                self._cache[self._name] = token
+            return token.access_token
+
+
+class InMemoryTokenCacheFactory:
+    """Create in-memory TokenCaches for sources."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cache: dict[str, Token] = {}
+
+    def get_cache(self, name: str) -> TokenCache:
+        """Return a `TokenCache` for the named source."""
+        return InMemoryTokenCache(name, self._lock, self._cache)

--- a/tests/source/test_azure_data_explorer.py
+++ b/tests/source/test_azure_data_explorer.py
@@ -16,6 +16,7 @@ from kukur.metadata import Metadata, fields
 from kukur.source.azure_data_explorer import from_config
 from kukur.source.azure_data_explorer.azure_data_explorer import _Sleeper
 from kukur.source.metadata import MetadataMapper, MetadataValueMapper
+from kukur.source.token_cache import NullTokenCache
 
 
 class MockKustoResponse:
@@ -310,6 +311,7 @@ def test_get_data(kusto_client) -> None:
         },
         MetadataMapper(),
         MetadataValueMapper(),
+        NullTokenCache(),
     )
     selector = SeriesSelector(
         "my_source", {"location": "Curitiba", "plant": "Plant02"}, "pressure"
@@ -342,6 +344,7 @@ def test_get_data_multiple_calls(kusto_client) -> None:
         },
         MetadataMapper(),
         MetadataValueMapper(),
+        NullTokenCache(),
     )
     selector = SeriesSelector(
         "my_source", {"location": "Curitiba", "plant": "Plant02"}, "pressure"
@@ -375,6 +378,7 @@ def test_result_set_too_large(kusto_client) -> None:
         },
         MetadataMapper(),
         MetadataValueMapper(),
+        NullTokenCache(),
     )
     selector = SeriesSelector(
         "my_source", {"location": "Curitiba", "plant": "Plant02"}, "pressure"
@@ -399,6 +403,7 @@ def test_search_with_metadata(_kusto_client) -> None:
         },
         MetadataMapper(),
         MetadataValueMapper(),
+        NullTokenCache(),
     )
     metadata_list = list(source.search(SeriesSearch("my_source")))
     assert len(metadata_list) == 6
@@ -419,6 +424,7 @@ def test_search_without_metadata(_kusto_client) -> None:
         },
         MetadataMapper(),
         MetadataValueMapper(),
+        NullTokenCache(),
     )
     metadata_list = list(source.search(SeriesSearch("my_source")))
     assert len(metadata_list) == 6
@@ -441,6 +447,7 @@ def test_search_with_custom_query(_kusto_client) -> None:
         },
         MetadataMapper(),
         MetadataValueMapper.from_config({"data type": {"FLOAT64": ["float"]}}),
+        NullTokenCache(),
     )
     all_metadata = list(source.search(SeriesSearch("my_source")))
     assert len(all_metadata) == 4
@@ -471,6 +478,7 @@ def test_get_data_custom_query(kusto_client) -> None:
         },
         MetadataMapper(),
         MetadataValueMapper(),
+        NullTokenCache(),
     )
     selector = SeriesSelector(
         "my_source", {"location": "Antwerp", "plant": "Plant02"}, "pressure"
@@ -504,6 +512,7 @@ def test_get_data_throttle(kusto_client) -> None:
         },
         MetadataMapper(),
         MetadataValueMapper(),
+        NullTokenCache(),
     )
     source._sleeper = _TestSleeper()
     selector = SeriesSelector(
@@ -534,6 +543,7 @@ def test_get_data_throttle_resolved(kusto_client) -> None:
         },
         MetadataMapper(),
         MetadataValueMapper(),
+        NullTokenCache(),
     )
     source._sleeper = _TestSleeper()
     selector = SeriesSelector(

--- a/tests/source/test_token_cache.py
+++ b/tests/source/test_token_cache.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2026 Timeseer.AI
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+from unittest.mock import patch
+
+from kukur.source.token_cache import (
+    InMemoryTokenCacheFactory,
+    Token,
+)
+
+
+def test_expires_none() -> None:
+    token = Token("a")
+    assert token.is_expired()
+
+
+def test_expires_not() -> None:
+    with patch("kukur.source.token_cache.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime.fromisoformat(
+            "2026-01-02T00:00:00+00:00"
+        )
+        mock_datetime.side_effect = datetime
+
+        token = Token("a", datetime.fromisoformat("2026-01-03T00:00:00+00:00"))
+        assert not token.is_expired()
+
+
+def test_expires_old() -> None:
+    with patch("kukur.source.token_cache.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime.fromisoformat(
+            "2026-01-02T00:00:00+00:00"
+        )
+        mock_datetime.side_effect = datetime
+
+        token = Token("a", datetime.fromisoformat("2026-01-01T00:00:00+00:00"))
+        assert token.is_expired()
+
+
+def test_expires_early() -> None:
+    with patch("kukur.source.token_cache.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime.fromisoformat(
+            "2026-01-02T00:00:00+00:00"
+        )
+        mock_datetime.side_effect = datetime
+
+        token = Token("a", datetime.fromisoformat("2026-01-02T00:00:30+00:00"))
+        assert not token.is_expired()
+
+        token = Token("a", datetime.fromisoformat("2026-01-02T00:00:29+00:00"))
+        assert token.is_expired()
+
+
+def test_cache_always() -> None:
+    calls = {"count": 0}
+
+    def _get_token(_) -> Token:
+        calls["count"] += 1
+        return Token("a")
+
+    factory = InMemoryTokenCacheFactory()
+    cache = factory.get_cache("test")
+    assert cache.get_token(_get_token) == "a"
+    assert cache.get_token(_get_token) == "a"
+    assert calls["count"] == 2
+
+
+def test_cache_token() -> None:
+    calls = {"count": 0}
+
+    def _get_token(_) -> Token:
+        calls["count"] += 1
+        return Token("a", datetime.fromisoformat("2026-01-03T00:00:00+00:00"))
+
+    with patch("kukur.source.token_cache.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime.fromisoformat(
+            "2026-01-02T00:00:00+00:00"
+        )
+        mock_datetime.side_effect = datetime
+
+        factory = InMemoryTokenCacheFactory()
+        cache = factory.get_cache("test")
+        assert cache.get_token(_get_token) == "a"
+        assert cache.get_token(_get_token) == "a"
+        assert calls["count"] == 1
+
+
+def test_cache_expires() -> None:
+    calls = {"count": 0}
+
+    def _get_token(r: str | None) -> Token:
+        calls["count"] += 1
+        if r is not None:
+            calls["refresh"] = True
+            assert r == "r"
+        return Token("a", datetime.fromisoformat("2026-01-03T00:00:00+00:00"), "r")
+
+    factory = InMemoryTokenCacheFactory()
+    cache = factory.get_cache("test")
+
+    with patch("kukur.source.token_cache.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime.fromisoformat(
+            "2026-01-02T00:00:00+00:00"
+        )
+        mock_datetime.side_effect = datetime
+
+        assert cache.get_token(_get_token) == "a"
+
+    with patch("kukur.source.token_cache.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime.fromisoformat(
+            "2026-01-03T00:00:00+00:00"
+        )
+        mock_datetime.side_effect = datetime
+
+        assert cache.get_token(_get_token) == "a"
+
+    assert calls["count"] == 2
+    assert calls["refresh"]

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,10 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'linux')",
 ]
 
+[options]
+exclude-newer = "2026-04-06T13:06:58.524696702Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "arro3-core"
 version = "0.8.0"
@@ -490,13 +494,13 @@ name = "cx-freeze"
 version = "8.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'linux'" },
-    { name = "freeze-core" },
+    { name = "filelock", marker = "platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux'" },
+    { name = "freeze-core", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64') or sys_platform != 'linux'" },
     { name = "lief", marker = "sys_platform == 'win32'" },
-    { name = "packaging" },
+    { name = "packaging", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64') or sys_platform != 'linux'" },
     { name = "python-msilib", marker = "python_full_version >= '3.13' and sys_platform == 'win32'" },
-    { name = "setuptools" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "setuptools", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64') or sys_platform != 'linux'" },
+    { name = "tomli", marker = "(python_full_version < '3.11' and platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64') or (python_full_version < '3.11' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/5a/d9b3e85db1639374652ff540e84a4912cb777053a30582d8c365d114f115/cx_freeze-8.6.3.tar.gz", hash = "sha256:d3bcdd0891f78d96f65d4879f362f163ad292bad76a42a1bddf58bcc9dcdb67b", size = 1377551, upload-time = "2026-03-23T22:18:45.68Z" }
 wheels = [
@@ -611,7 +615,7 @@ version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cabarchive", marker = "sys_platform == 'win32'" },
-    { name = "filelock" },
+    { name = "filelock", marker = "(platform_machine != 'aarch64' and platform_machine != 'armv7l' and platform_machine != 'i686' and platform_machine != 'ppc64le' and platform_machine != 's390x' and platform_machine != 'x86_64') or sys_platform != 'linux'" },
     { name = "striprtf", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/0d/1415721fce1b24d88c1460f67059678d7e5a5975baccf5dde790f2158bf7/freeze_core-0.6.1.tar.gz", hash = "sha256:819642aa58b4e2c19e1ade025d9563e437c07c90fe6ac5c891e8ecee2044a2ef", size = 1636378, upload-time = "2026-03-10T13:24:03.726Z" }


### PR DESCRIPTION
We don't depend on a file locking library, so persisting tokens has to be handled externally.