### PR TITLE
Retry when parquet reading fails on S3

### DIFF
--- a/kukur/inspect/__init__.py
+++ b/kukur/inspect/__init__.py
@@ -68,11 +68,14 @@ class DataOptions:
     `default_resource_type` assumes files without extension are of this type.
     """
 
+    DEFAULT_RETRY_COUNT = 5
+
     column_names: list[str] | None = None
     csv_delimiter: str | None = None
     csv_header_row: bool = True
     excel_header_row: bool = True
     default_resource_type: ResourceType | None = None
+    retry_count: int = DEFAULT_RETRY_COUNT
 
 
 @dataclass

--- a/kukur/inspect/arrow.py
+++ b/kukur/inspect/arrow.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import time
 from collections.abc import Generator
 from pathlib import PurePath
 
@@ -66,7 +67,24 @@ class BlobResource:
             stream = self.__fs.open_input_file(str(self.__path))
             rdr = parquet.ParquetFile(stream)
             column_names = _get_column_names(options)
-            yield from rdr.iter_batches(columns=column_names)
+            if options is not None:
+                retry_count = options.retry_count
+            else:
+                retry_count = DataOptions.DEFAULT_RETRY_COUNT
+            for i in range(rdr.num_row_groups):
+                for retry_index in range(retry_count):
+                    try:
+                        yield from rdr.read_row_group(
+                            i, columns=column_names
+                        ).to_batches()
+                    except (
+                        OSError
+                    ) as err:  # raised by PyArrow for internal errors on AWS
+                        if retry_index == retry_count - 1:
+                            raise err
+                        time.sleep(retry_index)
+                    break
+
         else:
             data_set = self.get_data_set(options)
             column_names = _get_column_names(options)


### PR DESCRIPTION
Streaming record batches fails randomly with INTERNAL_FAILURE. Read the Parquet file row group by row group and retry if any query fails.

We cannot retry the original request, because we currently stream the output to minimize memory usage.