### PR TITLE
Remove the unused SourceStructure functionality

### DIFF
--- a/kukur/__init__.py
+++ b/kukur/__init__.py
@@ -16,7 +16,6 @@ from .base import (
     InterpolationType,
     SeriesSearch,
     SeriesSelector,
-    SourceStructure,
 )
 from .exceptions import KukurException  # noqa
 from .metadata import Metadata
@@ -43,15 +42,6 @@ class Source(Protocol):
         self, selector: SeriesSelector, start_date: datetime, end_date: datetime
     ) -> pa.Table:
         """Return data for the given time series in the given time period."""
-        ...
-
-
-@typing.runtime_checkable
-class TagSource(Source, Protocol):
-    """TagSource is the interface that Kukur data sources that support tags and fields need to implement."""
-
-    def get_source_structure(self, selector: SeriesSelector) -> SourceStructure | None:
-        """Return the available tag keys and tag values and fields of a source."""
         ...
 
 

--- a/kukur/app.py
+++ b/kukur/app.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pyarrow as pa
 
-from kukur import Metadata, SeriesSearch, SeriesSelector, SourceStructure
+from kukur import Metadata, SeriesSearch, SeriesSelector
 from kukur.api_key.app import ApiKeys
 from kukur.exceptions import UnknownSourceException
 from kukur.repository import MigrationRunner, RepositoryRegistry
@@ -67,10 +67,6 @@ class Kukur:
         return self._get_source(selector.source).get_plot_data(
             selector, start_date, end_date, interval_count
         )
-
-    def get_source_structure(self, selector: SeriesSelector) -> SourceStructure | None:
-        """Return the structure of a source."""
-        return self._get_source(selector.source).get_source_structure(selector)
 
     def get_api_keys(self) -> ApiKeys:
         """Return the api keys."""

--- a/kukur/base.py
+++ b/kukur/base.py
@@ -164,23 +164,3 @@ class DataType(Enum):
     STRING = "STRING"
     DICTIONARY = "DICTIONARY"
     CATEGORICAL = "CATEGORICAL"
-
-
-@dataclass
-class SourceStructure:
-    """The SourceStructure defines the fields and tags that are present in the source."""
-
-    fields: list[str]
-    tag_keys: list[str]
-    tag_values: list[dict]
-
-    @classmethod
-    def from_data(cls, data: dict[str, Any]) -> "SourceStructure":
-        """Create a SourceStructure from a dictionary."""
-        return cls(data["fields"], data["tagKeys"], data["tagValues"])
-
-    def to_data(self):
-        """Convert to JSON object."""
-        return dict(
-            fields=self.fields, tagKeys=self.tag_keys, tagValues=self.tag_values
-        )

--- a/kukur/cli.py
+++ b/kukur/cli.py
@@ -61,7 +61,6 @@ def _serve(kukur_app: Kukur, server_config):
     server.register_get_handler("get_data", service.get_data)
     server.register_get_handler("get_plot_data", service.get_plot_data)
     server.register_action_handler("list_sources", kukur_app.list_sources)
-    server.register_action_handler("get_source_structure", service.get_source_structure)
     server.serve()
 
 

--- a/kukur/client.py
+++ b/kukur/client.py
@@ -14,7 +14,7 @@ from typing import Any
 import pyarrow as pa
 import pyarrow.flight as fl
 
-from kukur import Metadata, SeriesSearch, SeriesSelector, SourceStructure
+from kukur import Metadata, SeriesSearch, SeriesSelector
 
 
 @dataclass
@@ -198,23 +198,6 @@ class Client:
         results = list(self._get_client().do_action("list_sources"))
         data = json.loads(results[0].body.to_pybytes())
         return data
-
-    def get_source_structure(self, selector: SeriesSelector) -> SourceStructure | None:
-        """List all tags and fields from a source.
-
-        Returns:
-            A list of tag keys, tag values and fields that are configured in the source.
-        """
-        body = selector.to_data()
-        results = list(
-            self._get_client().do_action(
-                ("get_source_structure", json.dumps(body).encode())
-            )
-        )
-        data = json.loads(results[0].body.to_pybytes())
-        if data is None:
-            return None
-        return SourceStructure.from_data(data)
 
     def _get_client(self) -> Any:
         if self._client is None:

--- a/kukur/flight.py
+++ b/kukur/flight.py
@@ -10,7 +10,7 @@ from typing import Any
 import pyarrow.flight as fl
 from dateutil.parser import parse as parse_date
 
-from kukur import PlotSource, SeriesSelector, Source, TagSource
+from kukur import PlotSource, SeriesSelector, Source
 from kukur.app import Kukur
 from kukur.exceptions import InvalidSourceException
 
@@ -112,17 +112,6 @@ class KukurFlightServer:
             selector, start_date, end_date, interval_count
         )
         return fl.RecordBatchStream(data)
-
-    def get_source_structure(self, _, action: fl.Action) -> list[bytes]:
-        """Return the structure of a source for the given time series as JSON."""
-        request = json.loads(action.body.to_pybytes())
-        selector = SeriesSelector.from_data(request)
-        if not isinstance(self.__source, TagSource):
-            raise InvalidSourceException("get_source_structure not supported by source")
-        source_structure = self.__source.get_source_structure(selector)
-        if source_structure is None:
-            return [json.dumps(source_structure).encode()]
-        return [json.dumps(source_structure.to_data()).encode()]
 
 
 class KukurServerAuthHandler(fl.ServerAuthHandler):

--- a/kukur/source/__init__.py
+++ b/kukur/source/__init__.py
@@ -18,8 +18,6 @@ from kukur import (
     PlotSource,
     SeriesSearch,
     SeriesSelector,
-    SourceStructure,
-    TagSource,
     quality,
 )
 from kukur import Source as SourceProtocol
@@ -110,7 +108,7 @@ class Source:
     Source keeps them together.
     """
 
-    metadata: SourceProtocol | TagSource
+    metadata: SourceProtocol
     data: SourceProtocol
 
 
@@ -289,21 +287,6 @@ class SourceWrapper:
         )
         return self.__add_metadata(table, retry_count)
 
-    def get_source_structure(self, selector: SeriesSelector) -> SourceStructure | None:
-        """Return the structure of the source for the given series."""
-        if not isinstance(self.__source.metadata, TagSource):
-            return None
-        query_fn = functools.partial(
-            self.__source.metadata.get_source_structure, selector
-        )
-        structure, _ = _retry(
-            self.__query_retry_count,
-            self.__query_retry_delay,
-            query_fn,
-            f"Source structure query for {selector.source} failed",
-        )
-        return structure
-
     def __add_metadata(self, table: pa.Table, retry_count: int) -> pa.Table:
         """Describe the returned data in the metadata of the Arrow schema."""
         table = _add_query_statistics(table, retry_count)
@@ -400,7 +383,7 @@ class SourceFactory:
 
     def make_wrapper(
         self,
-        source: SourceProtocol | TagSource,
+        source: SourceProtocol,
         source_name: str,
         source_config: dict[str, Any],
     ) -> SourceWrapper:
@@ -452,7 +435,7 @@ class SourceFactory:
 
     def _make_source(
         self, source_id: str, source_type: str, source_config: dict[str, Any]
-    ) -> SourceProtocol | TagSource:
+    ) -> SourceProtocol:
         metadata_mapper = self._get_metadata_mapper(
             source_config.get("metadata_mapping")
         )

--- a/kukur/source/elasticsearch/elasticsearch.py
+++ b/kukur/source/elasticsearch/elasticsearch.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 
-from kukur import Metadata, SeriesSearch, SeriesSelector, SourceStructure
+from kukur import Metadata, SeriesSearch, SeriesSelector
 from kukur.exceptions import KukurException, MissingModuleException
 
 logger = logging.getLogger(__name__)
@@ -294,10 +294,6 @@ class ElasticsearchSource:
                     break
 
             return pa.Table.from_pydict({"ts": timestamps, "value": values})
-
-    def get_source_structure(self, _: SeriesSelector) -> SourceStructure | None:
-        """Return the available tag keys, tag value and tag fields."""
-        return None
 
     def _list_query_dsl(self, list_query: dict, sort: list) -> list:
         if self.__options.metadata_index is None:

--- a/kukur/source/influxdb/influxdb.py
+++ b/kukur/source/influxdb/influxdb.py
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 from collections.abc import Generator
 from datetime import datetime
 from typing import Any
@@ -12,7 +11,7 @@ from typing import Any
 import dateutil.parser
 import pyarrow as pa
 
-from kukur import Metadata, SeriesSearch, SeriesSelector, SourceStructure
+from kukur import Metadata, SeriesSearch, SeriesSelector
 from kukur.exceptions import InvalidDataError, MissingModuleException
 from kukur.source.influxdb.client import HAS_REQUESTS, ClientOptions, InfluxDBClient
 
@@ -108,30 +107,6 @@ class InfluxSource:
                 values.append(item[selector.field])
 
         return pa.Table.from_pydict({"ts": timestamps, "value": values})
-
-    def get_source_structure(self, _: SeriesSelector) -> SourceStructure | None:
-        """Return the available tag keys, tag value and tag fields."""
-        with self._get_client() as client:
-            query_tag_keys = "SHOW TAG KEYS"
-            tag_keys = []
-            for results in client.query(query=query_tag_keys).get_points():
-                tag_keys.extend(list(results.values()))
-            tag_keys = list(set(tag_keys))
-
-            query_fields = "SHOW FIELD KEYS"
-            fields = []
-            for results in client.query(query=query_fields).get_points():
-                for key, value in results.items():
-                    if key == "fieldKey":
-                        fields.append(value)
-
-            tag_key_placeholder = json.dumps(tag_keys)
-            query_tag_values = f"SHOW TAG VALUES WITH KEY IN {tag_key_placeholder.replace('[', '(').replace(']', ')')}"
-            tag_values = []
-            for result in client.query(query=query_tag_values).get_points():
-                if result not in tag_values:
-                    tag_values.append(result)
-            return SourceStructure(fields, tag_keys, tag_values)
 
 
 def _parse_influx_series(series: str) -> tuple[str, dict[str, str]]:

--- a/kukur/source/kukur/kukur.py
+++ b/kukur/source/kukur/kukur.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import pyarrow as pa
 
-from kukur import Metadata, SeriesSearch, SeriesSelector, SourceStructure
+from kukur import Metadata, SeriesSearch, SeriesSelector
 from kukur.client import Client
 
 
@@ -83,10 +83,3 @@ class KukurSource:
         return self.__client.get_plot_data(
             remote_selector, start_date, end_date, interval_count
         )
-
-    def get_source_structure(self, selector: SeriesSelector) -> SourceStructure | None:
-        """Return the source structure using the Flight service."""
-        remote_selector = SeriesSelector.from_tags(
-            self.__source_name, selector.tags, selector.field
-        )
-        return self.__client.get_source_structure(remote_selector)

--- a/kukur/source/simulator/simulator.py
+++ b/kukur/source/simulator/simulator.py
@@ -37,7 +37,6 @@ from kukur import (
     SeriesSearch,
     SeriesSelector,
     SignalGenerator,
-    SourceStructure,
 )
 from kukur.exceptions import (
     InvalidSourceException,
@@ -911,9 +910,6 @@ class SimulatorSource:
         for generator in self.__signal_generators[selector.tags["signal_type"]]:
             return generator.generate(selector, start_date, end_date)
         raise UnknownSignalTypeError(selector.tags["signal_type"])
-
-    def get_source_structure(self, _: SeriesSelector) -> SourceStructure | None:
-        """Return the structure of a source."""
 
     def _register_generator(self, config: dict):
         """Register a generator."""

--- a/tests/integration/test_influxdb.py
+++ b/tests/integration/test_influxdb.py
@@ -110,15 +110,3 @@ def test_data(client: Client):
     assert data["value"][0].as_py() == 8.412
     assert data["ts"][164].as_py() == end_date
     assert data["value"][164].as_py() == 3.235
-
-
-def test_get_source_structure(client: Client):
-    source_structure = client.get_source_structure(
-        SeriesSelector(suffix_source("noaa")),
-    )
-    assert len(source_structure.tag_keys) == 2
-    assert "location" in source_structure.tag_keys
-    assert len(source_structure.tag_values) == 5
-    assert {"key": "location", "value": "coyote_creek"} in source_structure.tag_values
-    assert len(source_structure.fields) == 6
-    assert "degrees" in source_structure.fields

--- a/tests/source/test_azure_data_explorer.py
+++ b/tests/source/test_azure_data_explorer.py
@@ -26,7 +26,7 @@ class MockKustoResponse:
         self.primary_results = [results_list]
 
 
-def source_structure_queries(_, query) -> MockKustoResponse:
+def search_queries(_, query) -> MockKustoResponse:
     if query == "['telemetry-data'] | distinct deviceId, plant, location":
         return MockKustoResponse(
             [
@@ -390,7 +390,7 @@ def test_result_set_too_large(kusto_client) -> None:
     assert len(data) == 10
 
 
-@patch("azure.kusto.data.KustoClient.execute", side_effect=source_structure_queries)
+@patch("azure.kusto.data.KustoClient.execute", side_effect=search_queries)
 def test_search_with_metadata(_kusto_client) -> None:
     source = from_config(
         {
@@ -412,7 +412,7 @@ def test_search_with_metadata(_kusto_client) -> None:
         assert metadata.get_field_by_name("sensorModel") == "AST20PT"
 
 
-@patch("azure.kusto.data.KustoClient.execute", side_effect=source_structure_queries)
+@patch("azure.kusto.data.KustoClient.execute", side_effect=search_queries)
 def test_search_without_metadata(_kusto_client) -> None:
     source = from_config(
         {
@@ -434,7 +434,7 @@ def test_search_without_metadata(_kusto_client) -> None:
         assert "location" in metadata.series.tags
 
 
-@patch("azure.kusto.data.KustoClient.execute", side_effect=source_structure_queries)
+@patch("azure.kusto.data.KustoClient.execute", side_effect=search_queries)
 def test_search_with_custom_query(_kusto_client) -> None:
     source = from_config(
         {

--- a/tests/source/test_influxdb.py
+++ b/tests/source/test_influxdb.py
@@ -66,49 +66,6 @@ SHOW_FIELD_KEYS = {
     ]
 }
 
-SHOW_TAG_KEYS = {
-    "results": [
-        {
-            "statement_id": 0,
-            "series": [
-                {
-                    "name": "h2o_feet",
-                    "columns": ["tagKey"],
-                    "values": [["location"]],
-                },
-                {
-                    "name": "h2o_temperature",
-                    "columns": ["tagKey"],
-                    "values": [["location"]],
-                },
-            ],
-        }
-    ]
-}
-
-SHOW_TAG_VALUES = {
-    "results": [
-        {
-            "statement_id": 0,
-            "series": [
-                {
-                    "name": "h2o_feet",
-                    "columns": ["key", "value"],
-                    "values": [
-                        ["location", "coyote_creek"],
-                        ["location", "santa_monica"],
-                    ],
-                },
-                {
-                    "name": "h2o_temperature",
-                    "columns": ["key", "value"],
-                    "values": [["location", "coyote_creek"]],
-                },
-            ],
-        }
-    ]
-}
-
 DATA = {
     "results": [
         {
@@ -156,10 +113,6 @@ def mocked_requests_get(*args, **kwargs):
         return MockResponse(SHOW_SERIES)
     if query == "SHOW FIELD KEYS":
         return MockResponse(SHOW_FIELD_KEYS)
-    if query == "SHOW TAG KEYS":
-        return MockResponse(SHOW_TAG_KEYS)
-    if query.startswith("SHOW TAG VALUES"):
-        return MockResponse(SHOW_TAG_VALUES)
     if query.strip().startswith("SELECT"):
         return MockResponse(DATA)
 
@@ -233,23 +186,6 @@ def test_get_data(_) -> None:
     assert len(table) == 2
     assert table["ts"][0].as_py() == datetime.fromisoformat("2019-09-17T00:00:00+00:00")
     assert table["value"][0].as_py() == 8.412
-
-
-@patch("requests.Session.get", side_effect=mocked_requests_get)
-def test_get_source_structure(_) -> None:
-    source_structure = _source().get_source_structure(SeriesSelector("influx"))
-    assert source_structure is not None
-    assert source_structure.tag_keys == ["location"]
-    assert REQUESTS[-1]["q"] == 'SHOW TAG VALUES WITH KEY IN ("location")'
-    assert source_structure.tag_values == [
-        {"key": "location", "value": "coyote_creek"},
-        {"key": "location", "value": "santa_monica"},
-    ]
-    assert sorted(source_structure.fields) == [
-        "degrees",
-        "level description",
-        "water_level",
-    ]
 
 
 def _error_response(*args, **kwargs):

--- a/tests/source/test_source_wrapper.py
+++ b/tests/source/test_source_wrapper.py
@@ -2,14 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from collections.abc import Generator
 from datetime import datetime, timedelta
 
 import pyarrow as pa
 import pytest
 
 from kukur import Metadata, SeriesSelector, quality
-from kukur.base import SourceStructure
 from kukur.quality import Quality, QualityMapper
 from kukur.source import Source, SourceWrapper, _add_query_statistics
 
@@ -27,29 +25,6 @@ class FakeSource:
     ) -> pa.Table:
         # end_date should not be part of the returned interval, but is here for easy comparison
         return pa.Table.from_pydict({"ts": [start_date, end_date], "value": [42, 24]})
-
-
-class FakeTagSource:
-    def search(
-        self, selector: SeriesSelector
-    ) -> Generator[SeriesSelector | Metadata, None, None]:
-        yield selector
-
-    def get_metadata(self, selector: SeriesSelector) -> Metadata:
-        return Metadata(selector)
-
-    def get_data(
-        self, _: SeriesSelector, start_date: datetime, end_date: datetime
-    ) -> pa.Table:
-        # end_date should not be part of the returned interval, but is here for easy comparison
-        return pa.Table.from_pydict({"ts": [start_date, end_date], "value": [42, 24]})
-
-    def get_source_structure(self, _: SeriesSelector) -> SourceStructure | None:
-        return SourceStructure(
-            ["fake_field"],
-            ["fake_tag_key"],
-            [{"key": "fake_tag_key", "value": "fake_tag_value"}],
-        )
 
 
 class EmptyOddHoursSource:
@@ -323,28 +298,6 @@ def test_exception_after_too_many_retries():
     )
     with pytest.raises(DummyError):
         wrapper.get_data(SELECTOR, START_DATE, END_DATE)
-
-
-def test_get_source_structure():
-    source = FakeTagSource()
-
-    wrapper = SourceWrapper(
-        Source(source, source), [], {"data_query_interval_seconds": 60 * 60}
-    )
-
-    result = wrapper.get_source_structure(SELECTOR)
-    assert result is not None
-
-
-def test_get_source_structure_not_implemented():
-    source = FakeSource()
-
-    wrapper = SourceWrapper(
-        Source(source, source), [], {"data_query_interval_seconds": 60 * 60}
-    )
-
-    result = wrapper.get_source_structure(SELECTOR)
-    assert result is None
 
 
 def test_not_implemented_metadata() -> None:


### PR DESCRIPTION
SourceStructure is not used by any consumer. Remove the dataclass, the TagSource protocol that only existed to declare get_source_structure and all implementations of it in the InfluxDB, Kukur, Elasticsearch and simulator sources.

This also removes the get_source_structure Flight action and its client method, so the action is no longer part of the wire protocol.